### PR TITLE
Implement "Random" as a sorting option, add standalone "Random" page

### DIFF
--- a/src/jelu-ui/src/App.vue
+++ b/src/jelu-ui/src/App.vue
@@ -194,6 +194,15 @@ const collapseDropdown = () => {
             <li @click="collapseDropdown()">
               <router-link
                 v-if="isLogged"
+                class="font-sans text-base capitalize"
+                :to="{ name: 'random' }"
+              >
+                {{ t('nav.random') }}
+              </router-link>
+            </li>
+            <li @click="collapseDropdown()">
+              <router-link
+                v-if="isLogged"
                 :to="{ name: 'add-book' }"
                 class="font-sans text-base capitalize"
               >
@@ -305,6 +314,15 @@ const collapseDropdown = () => {
               :to="{ name: 'to-read' }"
             >
               {{ t('nav.to_read') }}
+            </router-link>
+          </li>
+          <li>
+            <router-link
+              v-if="isLogged"
+              class="font-sans text-xl capitalize"
+              :to="{ name: 'random' }"
+            >
+              {{ "Random" }}
             </router-link>
           </li>
           <li>

--- a/src/jelu-ui/src/components/BookList.vue
+++ b/src/jelu-ui/src/components/BookList.vue
@@ -218,6 +218,12 @@ try {
         >
           {{ t('sorting.avg_rating') }}
         </o-radio>
+        <o-radio
+          v-model="sortBy"
+          native-value="random"
+        >
+          {{ t('sorting.random') }}
+        </o-radio>
       </div>
     </template>
     <template #filters>

--- a/src/jelu-ui/src/components/RandomList.vue
+++ b/src/jelu-ui/src/components/RandomList.vue
@@ -17,13 +17,13 @@ const { t } = useI18n({
       useScope: 'global'
     })
 
-useTitle('Jelu | To read')
+useTitle('Jelu | Random')
 
 const books: Ref<Array<UserBook>> = ref([]);
 
 const { total, page, pageAsNumber, perPage, updatePage, getPageIsLoading, updatePageLoading } = usePagination()
 
-const { sortQuery, sortOrder, sortBy, sortOrderUpdated } = useSort('creationDate,desc')
+const { sortQuery, sortOrder, sortBy, sortOrderUpdated } = useSort('random,desc')
 
 const { showSelect, selectAll, checkedCards, cardChecked, toggleEdit } = useBulkEdition(modalClosed)
 
@@ -54,14 +54,14 @@ const ownedAsBool = computed(() => {
   }
 )
 
-const getToReadIsLoading: Ref<boolean> = ref(false)
+const getRandomIsLoading: Ref<boolean> = ref(false)
 
-const getToRead = async () => {
-  getToReadIsLoading.value = true
+const getRandom = async () => {
+  getRandomIsLoading.value = true
   try {
     const res = await dataService.findUserBookByCriteria(
       eventTypes.value, null, userId.value,
-    true, ownedAsBool.value, null,
+    null, ownedAsBool.value, null,
     pageAsNumber.value - 1, perPage.value, sortQuery.value)
     total.value = res.totalElements
     books.value = res.content
@@ -71,42 +71,42 @@ const getToRead = async () => {
     else {
       page.value = "1"
     }
-    getToReadIsLoading.value = false
+    getRandomIsLoading.value = false
     updatePageLoading(false)
   } catch (error) {
     console.log("failed get books : " + error);
-    getToReadIsLoading.value = false
+    getRandomIsLoading.value = false
     updatePageLoading(false)
   }
 };
 
 // watches set above sometimes called twice
 // so getBooks was sometimes called twice at the same instant
-const throttledGetToRead = useThrottleFn(() => {
-  getToRead()
+const throttledGetRandom = useThrottleFn(() => {
+  getRandom()
 }, 100, false)
 
 watch([page, eventTypes, sortQuery, owned], (newVal, oldVal) => {
   console.log("all " + newVal + " " + oldVal)
   if (newVal !== oldVal) {
-    throttledGetToRead()
+    throttledGetRandom()
   }
 })
 
 function modalClosed() {
   console.log("modal closed")
-  throttledGetToRead()
+  throttledGetRandom()
 }
 
 const message = computed(() => {
   if (userId.value != null) {
     return t('labels.reading_list_from_name', { name: username.value })
   } else {
-    return t('nav.to_read')
+    return "Random"
   }
 } )
 
-getToRead()
+getRandom()
 
 </script>
 
@@ -118,79 +118,6 @@ getToRead()
     @update:open="open = $event"
     @update:sort-order="sortOrderUpdated"
   >
-    <template #sort-fields>
-      <div class="field">
-        <label class="label">{{ t('sorting.sort_by') }} : </label>
-        <o-radio
-          v-model="sortBy"
-          native-value="creationDate"
-        >
-          {{ t('sorting.date_added_to_list') }}
-        </o-radio>
-      </div>
-      <div class="field">
-        <o-radio
-          v-model="sortBy"
-          native-value="lastReadingEventDate"
-        >
-          {{ t('sorting.last_reading_event_date') }}
-        </o-radio>
-      </div>
-      <div class="field">
-        <o-radio
-          v-model="sortBy"
-          native-value="title"
-        >
-          {{ t('sorting.title') }}
-        </o-radio>
-      </div>
-      <div class="field">
-        <o-radio
-          v-model="sortBy"
-          native-value="publisher"
-        >
-          {{ t('sorting.publisher') }}
-        </o-radio>
-      </div>
-      <div class="field">
-        <o-radio
-          v-model="sortBy"
-          native-value="series"
-        >
-          {{ t('sorting.series') }}
-        </o-radio>
-      </div>
-      <div class="field">
-        <o-radio
-          v-model="sortBy"
-          native-value="pageCount"
-        >
-          {{ t('sorting.page_count') }}
-        </o-radio>
-      </div>
-      <div class="field">
-        <o-radio
-          v-model="sortBy"
-          native-value="usrAvgRating"
-        >
-          {{ t('sorting.user_avg_rating') }}
-        </o-radio>
-      </div>
-      <div class="field">
-        <o-radio
-          v-model="sortBy"
-          native-value="avgRating"
-        >
-          {{ t('sorting.avg_rating') }}
-        </o-radio>
-        <o-radio
-          v-model="sortBy"
-          native-value="random"
-        >
-          {{ t('sorting.random') }}
-        </o-radio>
-      </div>
-    </template>
     <template #filters>
       <div class="field flex flex-col capitalize gap-1">
         <label class="label">{{ t('reading_events.last_event_type') }} : </label>
@@ -309,7 +236,7 @@ getToRead()
     </div>
   </div>
   <div
-    v-else-if="getToReadIsLoading"
+    v-else-if="getRandomIsLoading"
     class="flex flex-row justify-center justify-items-center gap-3"
   >
     <o-skeleton
@@ -330,7 +257,7 @@ getToRead()
   </div>
   <div v-else>
     <h2 class="text-3xl typewriter">
-      {{ t('labels.nothing_to_read') }}
+      "Random"
     </h2>
     <span class="icon">
       <i class="mdi mdi-book-open-page-variant-outline mdi-48px" />

--- a/src/jelu-ui/src/components/RandomList.vue
+++ b/src/jelu-ui/src/components/RandomList.vue
@@ -263,14 +263,6 @@ getRandom()
       <i class="mdi mdi-book-open-page-variant-outline mdi-48px" />
     </span>
   </div>
-  <o-pagination
-    v-if="books.length > 0"
-    v-model:current="pageAsNumber"
-    :total="total"
-    order="centered"
-    :per-page="perPage"
-    @change="updatePage"
-  />
   <o-loading
     v-model:active="getPageIsLoading"
     :full-page="true"

--- a/src/jelu-ui/src/components/TagBooks.vue
+++ b/src/jelu-ui/src/components/TagBooks.vue
@@ -146,6 +146,12 @@ getBooks()
         >
           {{ t('sorting.modification_date') }}
         </o-radio>
+        <o-radio
+          v-model="sortBy"
+          native-value="random"
+        >
+          {{ t('sorting.random') }}
+        </o-radio>
       </div>
       <div class="field">
         <o-radio

--- a/src/jelu-ui/src/locales/en.json
+++ b/src/jelu-ui/src/locales/en.json
@@ -8,6 +8,7 @@
     "nav": {
       "my_books": "my books",
       "to_read": "to read list",
+      "random": "random",
       "add_book" : "add book",
       "dashboard" : "dashboard",
       "login" : "login",
@@ -144,6 +145,7 @@
         "date_added" : "Date added",
         "date_added_to_list" : "Date added to list",
         "title" : "Title",
+        "random": "Random",
         "publisher" : "Publisher",
         "series" : "Series",
         "series_number" : "Series number",

--- a/src/jelu-ui/src/router.ts
+++ b/src/jelu-ui/src/router.ts
@@ -63,6 +63,12 @@ const router = createRouter({
             beforeEnter: [isLogged],
         },
         {
+            path: '/random',
+            component: () => import(/* webpackChunkName: "recommend" */ './components/RandomList.vue'),
+            name: 'random',
+            beforeEnter: [isLogged],
+        },
+        {
             path: '/history',
             component: () => import(/* webpackChunkName: "recommend" */ './components/History.vue'),
             name: 'history',

--- a/src/main/kotlin/io/github/bayang/jelu/dao/BookRepository.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dao/BookRepository.kt
@@ -46,7 +46,6 @@ import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Repository
@@ -147,8 +146,7 @@ class BookRepository(
         }
         return PageImpl(
             query.map { resultRow -> wrapRow(resultRow, user.id.value) },
-            // Return a single page result if random sort is selected
-            if (checkIfRandomSorting(pageable)) PageRequest.of(0, pageable.pageSize) else pageable,
+            pageable,
             total,
         )
     }
@@ -405,8 +403,7 @@ class BookRepository(
         }
         return PageImpl(
             query.map { resultRow -> wrapRow(resultRow, user.id.value) },
-            // Return a single page result if random sort is selected
-            if (checkIfRandomSorting(pageable)) PageRequest.of(0, pageable.pageSize) else pageable,
+            pageable,
             total,
         )
     }
@@ -1069,8 +1066,7 @@ class BookRepository(
         val res = query.map { resultRow -> wrapUserBookRow(resultRow, ratingAlias, userRatingAlias) }
         return PageImpl(
             res,
-            // Return a single page result if random sort is selected
-            if (checkIfRandomSorting(pageable)) PageRequest.of(0, pageable.pageSize) else pageable,
+            pageable,
             total,
         )
     }

--- a/src/main/kotlin/io/github/bayang/jelu/dao/BookRepository.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dao/BookRepository.kt
@@ -22,11 +22,9 @@ import org.jetbrains.exposed.dao.load
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.ExpressionAlias
-import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.JoinType
-import org.jetbrains.exposed.sql.LongColumnType
 import org.jetbrains.exposed.sql.Query
-import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.Random
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SizedCollection
 import org.jetbrains.exposed.sql.SortOrder
@@ -94,11 +92,6 @@ fun formatLike(input: String): String {
     return "%$input%"
 }
 
-// Implement function for SQL RANDOM()
-object RandomOrder : Function<Long>(LongColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("RANDOM()") }
-}
-
 // Convenience checker for whether sort is "random" vs column name
 fun checkIfRandomSorting(pageable: Pageable): Boolean {
     // Check if sorting is specified and includes 'random'
@@ -146,7 +139,7 @@ class BookRepository(
         val total = query.count()
         if (checkIfRandomSorting(pageable)) {
             query.limit(pageable.pageSize)
-            query.orderBy(RandomOrder)
+            query.orderBy(Random())
         } else {
             query.limit(pageable.pageSize, pageable.offset)
             val orders: Array<Pair<Expression<*>, SortOrder>> = parseSorts(pageable.sort, Pair(BookTable.title, SortOrder.ASC_NULLS_LAST), BookTable)
@@ -404,7 +397,7 @@ class BookRepository(
         val total = query.count()
         if (checkIfRandomSorting(pageable)) {
             query.limit(pageable.pageSize)
-            query.orderBy(RandomOrder)  // Use the custom random function
+            query.orderBy(Random())  // Use the custom random function
         } else {
             query.limit(pageable.pageSize, pageable.offset)
             val orders: Array<Pair<Expression<*>, SortOrder>> = parseSorts(pageable.sort, Pair(BookTable.title, SortOrder.ASC_NULLS_LAST), BookTable)
@@ -1067,7 +1060,7 @@ class BookRepository(
         val total = query.count()
         if (checkIfRandomSorting(pageable)) {
             query.limit(pageable.pageSize)
-            query.orderBy(RandomOrder)  // Use the custom random function
+            query.orderBy(Random())  // Use the custom random function
         } else {
             query.limit(pageable.pageSize, pageable.offset)
             val orders: Array<Pair<Expression<*>, SortOrder>> = parseSorts(pageable.sort, Pair(UserBookTable.lastReadingEventDate, SortOrder.DESC_NULLS_LAST), cols)

--- a/src/main/kotlin/io/github/bayang/jelu/dao/BookRepository.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dao/BookRepository.kt
@@ -395,7 +395,7 @@ class BookRepository(
         val total = query.count()
         if (checkIfRandomSorting(pageable)) {
             query.limit(pageable.pageSize)
-            query.orderBy(Random())  // Use the custom random function
+            query.orderBy(Random())
         } else {
             query.limit(pageable.pageSize, pageable.offset)
             val orders: Array<Pair<Expression<*>, SortOrder>> = parseSorts(pageable.sort, Pair(BookTable.title, SortOrder.ASC_NULLS_LAST), BookTable)
@@ -1057,11 +1057,11 @@ class BookRepository(
         val total = query.count()
         if (checkIfRandomSorting(pageable)) {
             query.limit(pageable.pageSize)
-            query.orderBy(Random())  // Use the custom random function
+            query.orderBy(Random())
         } else {
             query.limit(pageable.pageSize, pageable.offset)
             val orders: Array<Pair<Expression<*>, SortOrder>> = parseSorts(pageable.sort, Pair(UserBookTable.lastReadingEventDate, SortOrder.DESC_NULLS_LAST), cols)
-            query.orderBy(*orders)    
+            query.orderBy(*orders)
         }
         val res = query.map { resultRow -> wrapUserBookRow(resultRow, ratingAlias, userRatingAlias) }
         return PageImpl(

--- a/src/test/kotlin/io/github/bayang/jelu/service/BookServiceTest.kt
+++ b/src/test/kotlin/io/github/bayang/jelu/service/BookServiceTest.kt
@@ -1312,7 +1312,7 @@ class BookServiceTest(
 
     @Test
     fun testQueryWithRandomOrder() {
-        // Create three books to validate response
+        // Create books to validate response
         val targetPageableSize = 24
         val booksToCreate = targetPageableSize + 4
         for (bookNumber in 1..booksToCreate) {
@@ -1320,13 +1320,13 @@ class BookServiceTest(
             val createUserBookDto = createUserBookDto(createBook)
             bookService.save(createUserBookDto, user(), null)
         }
-    
+
         val totalCheckRes = bookService.findUserBookByCriteria(user().id.value, null, null, null, null, null, Pageable.ofSize(booksToCreate))
         // Check total number of books created -- cast to Int for assert
         val totalNumberOfBooks = totalCheckRes.totalElements.toInt()
         Assertions.assertEquals(booksToCreate, totalNumberOfBooks)
 
-        val pageable = PageRequest.of(0, targetPageableSize, Sort.by("random").descending());
+        val pageable = PageRequest.of(0, targetPageableSize, Sort.by("random").descending())
         val randomCheckRes = bookService.findUserBookByCriteria(user().id.value, null, null, null, null, null, pageable)
         // Check number of randomly returned books (pageSize, not total)
         val randomNumberOfBooks = randomCheckRes.numberOfElements.toInt()


### PR DESCRIPTION
Inspired by the "Random" page segment in [Calibre-Web](https://github.com/janeczku/calibre-web), I really enjoy rediscovering items in my list randomly. To that end, this PR implements "Random" sort.

- API additions
  - Implements a convenience querybuilder leveraging RANDOM() to append to queries
  - Implements a convenience function to determine whether the passed sort order is "random"
  - Using this check, it will bypass the default `parseSort` method and directly apply the sort order
  - It further limits the query to a single page size
- Page Changes
  -  Adds "Random" as a sort option to:
      - Book List
      - To Read list
      - Shelves (tag) pages
  - Adds a standalone Random page, constrained to only Random sort
  