### PR TITLE
Link Series # tag on Book Cards

### DIFF
--- a/src/jelu-ui/src/components/BookCard.vue
+++ b/src/jelu-ui/src/components/BookCard.vue
@@ -232,13 +232,14 @@ watch(checked, (newVal, oldVal) => {
           class="badge"
         >{{ eventText }}</span>
         <div class="flex">
-          <span
+          <router-link
             v-if="book.book.series && book.book.series.length > 0"
             v-tooltip="book.book.series[0].name"
             class="badge mx-1"
+            :to="{ name: 'series', params: { seriesId: book.book.series[0].seriesId } }"
           >
             #{{ book.book.series[0].numberInSeries }}
-          </span>
+          </router-link>
           <span
             v-if="book.userAvgRating"
             v-tooltip="t('labels.user_avg_rating', {rating : book.userAvgRating})"


### PR DESCRIPTION
Small PR to link the Series "#" tag on Book cards to the series page.

Example of what is now linked:
<img width="247" alt="Untitled 2" src="https://github.com/bayang/jelu/assets/37663/993a79ed-b18b-4299-abd3-01bd1427e0bd">
