### PR TITLE
Allow typing into date input fields during book event editing.

### DIFF
--- a/src/jelu-ui/src/components/ReadingEventModal.vue
+++ b/src/jelu-ui/src/components/ReadingEventModal.vue
@@ -123,6 +123,7 @@ const deleteEvent = () => {
           <datepicker
             v-model="currentEvent.startDate"
             class="input input-primary"
+            :typeable="true"
             :clearable="false"
           >
             <template #clear="{ onClear }">
@@ -155,6 +156,7 @@ const deleteEvent = () => {
           <datepicker
             v-model="currentEvent.endDate"
             class="input input-primary"
+            :typeable="true"
             :clearable="true"
           >
             <template #clear="{ onClear }">
@@ -244,6 +246,7 @@ const deleteEvent = () => {
             v-model="currentCreateEvent.startDate"
             class="input input-primary"
             :clearable="true"
+            :typeable="true"
           >
             <template #clear="{ onClear }">
               <button @click="onClear">
@@ -276,6 +279,7 @@ const deleteEvent = () => {
             v-model="currentCreateEvent.eventDate"
             class="input input-primary"
             :clearable="true"
+            :typeable="true"
           >
             <template #clear="{ onClear }">
               <button @click="onClear">


### PR DESCRIPTION
Allow typing date into field to set selection of datepickers when editing reading events.

Does not apply to the different datepicker element when editing a book's metadata.