### PR TITLE
Detect if ISBN field contains ASIN for Metadata search

### DIFF
--- a/src/main/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProvider.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProvider.kt
@@ -178,13 +178,13 @@ class CalibreMetadataProvider(
     internal fun determineCodeType(code: String): String {
         // Regex for ISBN-10: Either 10 digits, or 9 digits followed by 'X'
         val isbn10Regex = Regex("^(?=[0-9X]{10}\$)([0-9]{9}[X]|[0-9]{10})\$")
-    
+
         // Regex for ISBN-13: Starts with 978 or 979 followed by 10 digits
         val isbn13Regex = Regex("^(978|979)[0-9]{10}\$")
-    
+
         // Regex for ASIN: 10 alphanumeric characters
         val asinRegex = Regex("^[A-Z0-9]{10}\$")
-    
+
         return when {
             // Strip all hyphens and spaces from the code before matching
             isbn10Regex.matches(code.replace("-", "").replace(" ", "")) -> "ISBN-10"

--- a/src/test/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProviderTest.kt
+++ b/src/test/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProviderTest.kt
@@ -137,4 +137,31 @@ class CalibreMetadataProviderTest(
         Assertions.assertEquals(1, metadata.authors.size)
         Assertions.assertEquals("J. R. R. Tolkien", metadata.authors.first())
     }
+
+    @Test
+    fun testASINMatch() {
+        // https://www.amazon.com/Fellowship-Ring-Being-First-Rings-ebook/dp/B007978NPG -- Kindle Edition
+        var input = "B007978NPG"
+        val resultingCodeType = calibreMetadataProvider.determineCodeType(input)
+        Assertions.assertEquals("ASIN", resultingCodeType)
+    }
+
+    @Test
+    fun testISBN10Match() {
+        // https://www.amazon.com/Fellowship-Ring-Being-First-Rings/dp/0547928211 -- Paperback ISBN 10
+        var input = "0547928211"
+        val resultingCodeType = calibreMetadataProvider.determineCodeType(input)
+        Assertions.assertEquals("ISBN-10", resultingCodeType)
+    }
+
+    @Test
+    fun testISB13match() {
+        // // https://www.amazon.com/Fellowship-Ring-Being-First-Rings/dp/0547928211 -- Paperback ISBN 13
+        var plainInput = "978-0547928210"
+        val plainResultingCodeType = calibreMetadataProvider.determineCodeType(plainInput)
+        var dashedInput = "978-0547928210"
+        val dashedResultingCodeType = calibreMetadataProvider.determineCodeType(dashedInput)
+        Assertions.assertEquals("ISBN-13", plainResultingCodeType)
+        Assertions.assertEquals("ISBN-13", dashedResultingCodeType)
+    }
 }

--- a/src/test/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProviderTest.kt
+++ b/src/test/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProviderTest.kt
@@ -157,7 +157,7 @@ class CalibreMetadataProviderTest(
     @Test
     fun testISB13match() {
         // // https://www.amazon.com/Fellowship-Ring-Being-First-Rings/dp/0547928211 -- Paperback ISBN 13
-        var plainInput = "978-0547928210"
+        var plainInput = "9780547928210"
         val plainResultingCodeType = calibreMetadataProvider.determineCodeType(plainInput)
         var dashedInput = "978-0547928210"
         val dashedResultingCodeType = calibreMetadataProvider.determineCodeType(dashedInput)


### PR DESCRIPTION
### ASIN search PR
This PR allows a user to paste in the ASIN of a book into the ISBN field. 

I initially made changes to add an ASIN field, but that felt like a much larger change for the same effect and added unnecessary UI bloat. An argument could be made for updating the label to indicate that ASIN is supported, but for now I implemented this as an "easter egg". If you type in an ASIN, instead of failing because `fetch-ebook-metadata` was explicitly told it was an ISBN, it will now check if it is an ASIN and proceed with the same metadata lookup.

### Other items in my fork
I do want to briefly tell you what my plan is for many of my little edits. For small, atomic changes I'll be opening PRs. But I have other things I've changed to my preference (default pagination size) or added functionality that I'm unsure whether it fits the goal of the project. For those, I am maintaining a fork/branch that I am constantly rebasing against your `main` branch whenever you push changes. In this way, I'm maintaining a set of atomic patches you are free to pull in (or I will PR) and others can use. A few examples right now, if you'd like me to push them up too:

- Jumping from search to looking up a book to add (autopopulating the query), intended for "check if I have this, add if I don't" workflow.
- Homepage lists the latest things read/dropped based on when they were read, not when the reading event was created.
- Automatically selecting the latest year on history and stats pages