### PR TITLE
Show latest reading events by event date, not event creation date.

### DIFF
--- a/src/jelu-ui/src/components/Welcome.vue
+++ b/src/jelu-ui/src/components/Welcome.vue
@@ -69,7 +69,7 @@ const nonCurrentlyReadingEvents: Array<ReadingEventType> = [ReadingEventType.DRO
 const getMyEvents = async () => {
   recentEventsIsLoading.value = true
   try {
-    const res = await dataService.myReadingEvents(nonCurrentlyReadingEvents, undefined, undefined, undefined, undefined, undefined, 0, 8)
+    const res = await dataService.myReadingEvents(nonCurrentlyReadingEvents, undefined, undefined, undefined, undefined, undefined, 0, 8, 'endDate,desc')
     const notCurrentlyReading = res.content.filter(e => e.eventType !== ReadingEventType.CURRENTLY_READING)
     events.value = notCurrentlyReading
     recentEventsIsLoading.value = false


### PR DESCRIPTION
Adjusts the selection for homepage reading events to pull the most recent occurrences, not latest created, reading events.