### PR TITLE
Add cache-buster string to Cover Image filenames

### DIFF
--- a/src/main/kotlin/io/github/bayang/jelu/utils/FileUtils.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/utils/FileUtils.kt
@@ -1,3 +1,8 @@
 package io.github.bayang.jelu.utils
 
-fun imageName(title: String, bookId: String, extension: String): String = "$title-$bookId.$extension"
+fun imageName(title: String, bookId: String, extension: String): String {
+    // Generate 8 character random string
+    val cacheBuster = List(8) { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".random() }.joinToString("")
+    val imageName = "$title-$bookId.$cacheBuster.$extension"
+    return imageName
+}


### PR DESCRIPTION
Add a random 8 character string into filename paths when downloading or saving new cover images. This random string will break any caching (browser or especially useful for Cloudflare/proxies) and serve the new image with a different URL.

Backwards compatible as it only applies on save. Current covers will serve with their name until a new image is uploaded instead.