### PR TITLE
Update goodreads plugin to v1.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,12 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
       && rm -rf /var/lib/apt/lists/* \
       && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin install_dir=/ isolated=y \
       && strip --remove-section=.note.ABI-tag /calibre/lib/libQt6Core.so.6 \
-      && curl -L -o goodreads.zip https://github.com/kiwidude68/calibre_plugins/releases/download/goodreads-v1.7.9/goodreads-v1.7.9.zip \
+      && curl -L -o goodreads.zip https://github.com/kiwidude68/calibre_plugins/releases/download/goodreads-v1.8.2/goodreads-v1.8.2.zip \
       && /calibre/calibre-customize --add-plugin goodreads.zip \
       && rm goodreads.zip; \
   else \
       apt-get update && apt-get install --no-install-recommends --yes calibre \
-      && curl -L -o goodreads.zip https://github.com/kiwidude68/calibre_plugins/releases/download/goodreads-v1.7.9/goodreads-v1.7.9.zip \
+      && curl -L -o goodreads.zip https://github.com/kiwidude68/calibre_plugins/releases/download/goodreads-v1.8.2/goodreads-v1.8.2.zip \
       && calibre-customize --add-plugin goodreads.zip \
       && rm goodreads.zip; \
   fi


### PR DESCRIPTION
Included below is an exert from the goodreads plugin's change log with the relevant versions.

## [1.8.2] - 2024-06-13
### Fixed
- Fix casing of goodreads identifier in code so right-click remove in calibre feature will work (Terisa).

## [1.8.1] - 2023-03-24
### Fixed
- Author metadata change of just taking the primary contributor (first) when a book has no contributors with a role of Author like comics.

## [1.8.0] - 2023-03-19
### Fixed
- Changed the source from where the authors metadata is being scraped from, to better respect turning off the `Get all contributing authors` setting so as to not always return all authors. Note pseudonyms for authors will return both names.

## [1.7.10] - 2023-03-17
### Added
- Tamil translation