### PR TITLE
fix: userBook details on bookCard in search, author, and series views

### DIFF
--- a/src/jelu-ui/src/utils/ObjectUtils.ts
+++ b/src/jelu-ui/src/utils/ObjectUtils.ts
@@ -30,7 +30,20 @@ export class ObjectUtils {
   public static toUserBook = (book: Book): UserBook => {
     const converted = {
       id: book.userBookId != null ? book.userBookId : null,
-      book: book
+      book: book,
+      lastReadingEvent: book.userbook?.lastReadingEvent != null ? book.userbook?.lastReadingEvent : null,
+      lastReadingEventDate: book.userbook?.lastReadingEventDate != null ? book.userbook?.lastReadingEventDate : null,
+      creationDate: book.userbook?.creationDate != null ? book.userbook?.creationDate : null,
+      modificationDate: book.userbook?.modificationDate != null ? book.userbook?.modificationDate : null,
+      personalNotes: book.userbook?.personalNotes != null ? book.userbook?.personalNotes : null,
+      owned: book.userbook?.owned != null ? book.userbook?.owned : null,
+      borrowed: book.userbook?.borrowed != null ? book.userbook?.borrowed : null,
+      toRead: book.userbook?.toRead != null ? book.userbook?.toRead : null,
+      readingEvents: book.userbook?.readingEvents != null ? book.userbook?.readingEvents : null,
+      percentRead: book.userbook?.percentRead != null ? book.userbook?.percentRead : null,
+      currentPageNumber: book.userbook?.currentPageNumber != null ? book.userbook?.currentPageNumber : null,
+      avgRating: book.userbook?.avgRating != null ? book.userbook?.avgRating : null,
+      userAvgRating: book.userbook?.userAvgRating != null ? book.userbook?.userAvgRating : null
     } as UserBook
     // console.log('after')
     // console.log(converted)


### PR DESCRIPTION
This is just a UI bugfix, no change to backend.

Currently details such as owned and to-read are not shown on the BookCard when on the search, author, or series pages. This update allows that data to be displayed. 

Testing Performed:
Load book types that are owned, toRead, and that are not in my library on 

- search
- series
- book data
- author 

pages. Confirmed expected functionality is now included and did not see any regressions. Confirmed no other places are using this method. 