### PR TITLE
Better align book details when shown in a grid

### DIFF
--- a/src/jelu-ui/src/components/BookCard.vue
+++ b/src/jelu-ui/src/components/BookCard.vue
@@ -199,6 +199,7 @@ watch(checked, (newVal, oldVal) => {
     <div class="card-body">
       <router-link
         v-if="book.id != null"
+        class="grow"
         :to="{ name: 'book-detail', params: { bookId: book.id } }"
       >
         <h2
@@ -210,6 +211,7 @@ watch(checked, (newVal, oldVal) => {
       </router-link>
       <router-link
         v-else
+        class="grow"
         :to="{ name: 'book-reviews', params: { bookId: book.book.id } }"
       >
         <h2


### PR DESCRIPTION
In a book grid, the title, author and status are shown in a column with no real layout constraints. This means if a book has a long title, its author and status won't line up with a different book with a short title, which makes scanning across the grid annoying.

To fix this, give the title the flex-grow property so it'll expand to fill the available room. Authors and status will then be bottom-aligned.

| Before | After |
|--------|--------|
| <img src=https://github.com/user-attachments/assets/65fe8db0-101d-4801-b057-a3f8ba06483f> | <img src=https://github.com/user-attachments/assets/07b844af-aa3f-49bc-a2e8-8ee4e6a394b9> |
