### PR TITLE
Update Calibre Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
       && rm -rf /var/lib/apt/lists/* && \
       mkdir -p \
         /opt/calibre && \
-      CALIBRE_VERSION="7.24.0" && \
+      CALIBRE_VERSION="8.4.0" && \
       CALIBRE_URL="https://download.calibre-ebook.com/${CALIBRE_VERSION}/calibre-${CALIBRE_VERSION}-x86_64.txz" && \
       curl -o \
         /tmp/calibre-tarball.txz -L \
@@ -92,7 +92,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
       && rm -rf /var/lib/apt/lists/* && \
       mkdir -p \
         /opt/calibre && \
-      CALIBRE_VERSION="7.24.0" && \
+      CALIBRE_VERSION="8.4.0" && \
       CALIBRE_URL="https://download.calibre-ebook.com/${CALIBRE_VERSION}/calibre-${CALIBRE_VERSION}-arm64.txz" && \
       curl -o \
         /tmp/calibre-tarball.txz -L \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,6 @@ WORKDIR app
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 
-ARG DEPENDENCY=build/dependency
-COPY ${DEPENDENCY}/dependencies/ ./
-COPY ${DEPENDENCY}/spring-boot-loader/ ./
-COPY ${DEPENDENCY}/snapshot-dependencies/ ./
-COPY ${DEPENDENCY}/application/ ./
-
 ENV JELU_DATABASE_PATH="/database/"
 ENV JELU_FILES_IMAGES="/files/images/"
 ENV JELU_FILES_IMPORTS="/files/imports/"
@@ -110,6 +104,12 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
           && calibre-customize --add-plugin goodreads.zip \
           && rm goodreads.zip; \
   fi
+
+ARG DEPENDENCY=build/dependency
+COPY ${DEPENDENCY}/dependencies/ ./
+COPY ${DEPENDENCY}/spring-boot-loader/ ./
+COPY ${DEPENDENCY}/snapshot-dependencies/ ./
+COPY ${DEPENDENCY}/application/ ./
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher", "--spring.config.additional-location=optional:file:/config/"]
 EXPOSE 11111


### PR DESCRIPTION
Updates the Calibre version from 7.24.0 -> 8.4.0 which fixes searching by ASIN. Before this upgrade, searching by an ASIN would always fail for me. Output look look like the following:

```
Running identify query with parameters:
{'title': None, 'authors': [], 'identifiers': {'asin': 'B0CCXP3F8S'}, 'timeout': 30}
Using plugins: Google (1, 1, 1), Amazon.com (1, 3, 12)
The log from individual plugins is below

****************************** Google (1, 1, 1) ******************************
Found 0 results
Downloading from Google took 0.0064852237701416016
Insufficient metadata to construct query

********************************************************************************

****************************** Amazon.com (1, 3, 12) ******************************
Found 0 results
Downloading from Amazon.com took 0.6213510036468506
User-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
Server: auto
Making bing query: https://www.bing.com/search?q=B0CCXP3F8S+site%3Awww.amazon.com
Bing returned no results
No search engine results for terms: B0CCXP3F8S
No matches found with query: ['B0CCXP3F8S']

********************************************************************************
The identify phase took 0.81 seconds
The longest time (0.621351) was taken by: Amazon.com
Merging results from different sources
We have 0 merged results, merging took: 0.00 seconds

No results found
```

After upgrading to 8.4.0 this error no longer occurs. Funny enough, if you run the bing query yourself, you can see that it does actually find a result, but for some reason the `fetch-ebook-metadata` script doesn't parse it correctly.

Although frequent queries will pretty quickly result in Amazon blocking with a CAPTCHA, at least it is possible to search by ASIN again with the most recent version of Calibre.