### PR TITLE
Draft: feat: add error message to AutoImportFormModal

### DIFF
--- a/src/jelu-ui/src/components/AutoImportFormModal.vue
+++ b/src/jelu-ui/src/components/AutoImportFormModal.vue
@@ -75,6 +75,10 @@ const isValid = computed(() => StringUtils.isNotBlank(form.title)
 || StringUtils.isNotBlank(form.isbn)
 || StringUtils.isNotBlank(form.authors))
 
+const formattedErrorMessage = computed(() => {
+  return metadata.value?.pluginErrorMessage?.replace(/\n/g, '<br>') || ''
+})
+
 let barcodeReader: any = null
 
 function toggleScanModal() {
@@ -262,8 +266,30 @@ function pluginsModalClosed() {
     <div 
       class="flex flex-col items-center"
     >
+      <div
+        v-if="metadata != null && metadata.errorType != undefined"
+      >
+        <p class="text-error">
+          {{ t('errors.metadata.' + metadata.errorType) }}
+        </p>
+        <div class="collapse">
+          <input type="checkbox" />
+          <div class="collapse-title text-xl font-medium capitalize">
+            {{ t('errors.details') }}
+          </div>
+          <blockquote
+            v-if="formattedErrorMessage"
+            class="collapse-content"
+          >
+            <p
+              v-html="formattedErrorMessage"
+              class="whitespace-pre-line text-error"
+            />
+          </blockquote>
+        </div>
+      </div>
       <MetadataDetail
-        v-if="metadata != null"
+        v-else-if="metadata != null"
         :metadata="metadata"
       />
       <div

--- a/src/jelu-ui/src/locales/en.json
+++ b/src/jelu-ui/src/locales/en.json
@@ -386,5 +386,12 @@
         "source" : "source",
         "last_activity" : "last activity",
         "activity" : "login activity"
+    },
+    "errors" : {
+        "metadata" : {
+            "EXIT_CODE_NOT_ZERO" : "fetch metadata plugin exited abnormally",
+            "EXCEPTION_CAUGHT" : "exception was raised while calling metadata plugin"
+        },
+        "details" : "error details"
     }
 }

--- a/src/jelu-ui/src/model/Metadata.ts
+++ b/src/jelu-ui/src/model/Metadata.ts
@@ -1,3 +1,5 @@
+import { MetadataError } from './MetadataError';
+
 export interface Metadata {
     title?: string,
     isbn10?:string,
@@ -20,4 +22,6 @@ export interface Metadata {
     openlibraryId?: string,
     noosfereId?: string,
     inventaireId?: string,
+    errorType?: MetadataError,
+    pluginErrorMessage?: string,
 }

--- a/src/jelu-ui/src/model/MetadataError.ts
+++ b/src/jelu-ui/src/model/MetadataError.ts
@@ -1,0 +1,4 @@
+export enum MetadataError {
+    EXIT_CODE_NOT_ZERO = 'EXIT_CODE_NOT_ZERO',
+    EXCEPTION_CAUGHT = 'EXCEPTION_CAUGHT',
+}

--- a/src/main/kotlin/io/github/bayang/jelu/dto/MetadataDto.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dto/MetadataDto.kt
@@ -22,6 +22,8 @@ data class MetadataDto(
     var openlibraryId: String? = null,
     var inventaireId: String? = null,
     var noosfereId: String? = null,
+    var errorType: MetadataError? = null,
+    var pluginErrorMessage: String? = null,
 )
 data class MetadataRequestDto(
     val isbn: String? = null,

--- a/src/main/kotlin/io/github/bayang/jelu/dto/MetadataError.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dto/MetadataError.kt
@@ -1,0 +1,6 @@
+package io.github.bayang.jelu.dto
+
+enum class MetadataError {
+    EXIT_CODE_NOT_ZERO,
+    EXCEPTION_CAUGHT,
+}

--- a/src/main/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProvider.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/service/metadata/providers/CalibreMetadataProvider.kt
@@ -18,10 +18,22 @@ import java.util.Optional
 
 private val logger = KotlinLogging.logger {}
 
+// Add this interface for dependency injection
+interface ProcessBuilderFactory {
+    fun createProcessBuilder(): ProcessBuilder
+}
+
+// Add this implementation for production use
+@Service
+class DefaultProcessBuilderFactory : ProcessBuilderFactory {
+    override fun createProcessBuilder(): ProcessBuilder = ProcessBuilder()
+}
+
 @Service
 class CalibreMetadataProvider(
     private val properties: JeluProperties,
     private val opfParser: OpfParser,
+    private val processBuilderFactory: ProcessBuilderFactory = DefaultProcessBuilderFactory(),
 ) : IMetaDataProvider {
 
     companion object {
@@ -106,7 +118,7 @@ class CalibreMetadataProvider(
             commandArray.add("-c")
             commandArray.add(targetCover.absolutePath)
         }
-        val builder = ProcessBuilder()
+        val builder = processBuilderFactory.createProcessBuilder()
         logger.trace { "fetch metadata command : $commandArray" }
         builder.command(commandArray)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)


### PR DESCRIPTION
First off, thanks so much for your work on this project. I've been a long-time (about a year now) user of Jelu. As someone that really wants to track books that I've read in a way that I can own and customize, I really appreciate your effort on this project and for sharing it with us!

Please go easy on me on this one, I'm not a frontend or Kotlin developer, so I've probably majorly messed this up in several different ways. Thus I'm marking this PR as a Draft. I'm super open to any sort of feedback about this PR, even if it is just that the project doesn't like the approach or doesn't agree that this is a problem.

**Outstanding Items:**

* [ ] Receive feedback on the approach from @bayang 
* [ ] Add the rest of the languages for localization text
* [ ] Add error message functionality to other metadata providers
* [ ] Understand if there is anyway good way to localize the error message from the plugin provider

I frequently use the Auto Import functionality of Jelu. One of the few things that I've found frustrating with Jelu is that the Auto-Import somewhat regularly encounters errors. When it happens, I usually have no idea what happens, I'll get a box that looks like:

![image](https://github.com/user-attachments/assets/a64838b9-8a5c-4b46-a428-c0ff724fef41)

Since it has a `cover image` I actually thought for a long time that it had found a result, but that the metadata system just didn't have any info for the book. It is only recently as I started to look into Jelu more, that I realized that this is the screen that is shown when the metadata plugin returns an empty result because of some sort of error.

To that end, in this PR I've attempted to show the user:

1. That there is an error
2. Give the user an option to go into the weeds and see information directly from the metadata plugin

After this PR (at least in the English localization) it will display the following:

![image](https://github.com/user-attachments/assets/39230018-a693-4369-a658-452b4a74e09b)

![image](https://github.com/user-attachments/assets/49e02d39-1030-4964-8d69-7e0bcbecbb56)
