### PR TITLE
fix: Can't fetch metadata #127

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
       fonts-wqy-microhei \
       libxcomposite1 \
       libxdamage1 \
+      libxfixes3 \
       libxrandr2 \
       libxtst6 \
       libxkbfile1 \
@@ -77,6 +78,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
       fonts-wqy-microhei \
       libxcomposite1 \
       libxdamage1 \
+      libxfixes3 \
       libxrandr2 \
       libxtst6 \
       libxkbfile1 \


### PR DESCRIPTION
add 'libxfixes3' to list of installed packages, which is a required dependency of PyQt6.QtWebEngineCore, used by fetch-ebook-metadata