### PR TITLE
feat: add token authentication

### DIFF
--- a/src/jelu-ui/src/components/AdminBase.vue
+++ b/src/jelu-ui/src/components/AdminBase.vue
@@ -21,7 +21,8 @@ const items = ref([{ name:t('settings.profile'), tooltip:t('settings.my_profile'
                 { name:t('settings.imports'), icon:"bxs-file-plus", href:"/profile/imports", tooltip: t('settings.csv_import') },
                 { name:t('settings.messages'), icon:"bxs-message-alt-detail", href:"/profile/messages" },
                 { name:t('settings.stats'), icon:"bxs-chart", href:"/profile/stats", tooltip: t('settings.stats') },
-                { name:t('settings.users'), icon:"bxs-user-detail", href:"/profile/users", tooltip: t('settings.users') }
+                { name:t('settings.users'), icon:"bxs-user-detail", href:"/profile/users", tooltip: t('settings.users') },
+                { name:t('settings.api_tokens'), icon:"bxs-key", href:"/profile/api-tokens", tooltip: t('settings.api_tokens') }
                 ])
 
 if (store.getters.isAdmin && store.getters.getUser != null && store.getters.getUser.provider !== Provider.PROXY) {

--- a/src/jelu-ui/src/components/ApiTokens.vue
+++ b/src/jelu-ui/src/components/ApiTokens.vue
@@ -1,0 +1,395 @@
+<script setup lang="ts">
+import { useOruga } from "@oruga-ui/oruga-next"
+import { useTitle } from '@vueuse/core'
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useStore } from 'vuex'
+import { key } from '../store'
+import dataService from "../services/DataService"
+import { ObjectUtils } from "../utils/ObjectUtils"
+import { ApiToken, TokenScope, CreateApiToken } from "../model/ApiToken"
+import dayjs from "dayjs"
+
+const { t } = useI18n({
+  inheritLocale: true,
+  useScope: 'global'
+})
+
+useTitle('Jelu | API Tokens')
+
+const store = useStore(key)
+const oruga = useOruga()
+
+const tokens = ref<ApiToken[]>([])
+const scopes = ref<TokenScope[]>([])
+const loading = ref(false)
+const showCreateModal = ref(false)
+const showTokenModal = ref(false)
+const createdRawToken = ref('')
+
+const form = ref<CreateApiToken>({
+  name: '',
+  scopes: [],
+  expiresAt: undefined
+})
+
+const expirationOption = ref('never')
+const customExpiration = ref('')
+
+onMounted(async () => {
+  await loadTokens()
+  await loadScopes()
+})
+
+async function loadTokens() {
+  loading.value = true
+  try {
+    tokens.value = await dataService.getApiTokens()
+  } catch (err: any) {
+    console.log('error loading tokens', err)
+    ObjectUtils.toast(oruga, "danger", t('api_tokens.load_error'), 4000)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadScopes() {
+  try {
+    scopes.value = await dataService.getApiTokenScopes()
+  } catch (err: any) {
+    console.log('error loading scopes', err)
+  }
+}
+
+async function createToken() {
+  try {
+    // Handle expiration
+    let expiresAt: string | undefined = undefined
+    if (expirationOption.value === '30days') {
+      expiresAt = dayjs().add(30, 'day').toISOString()
+    } else if (expirationOption.value === '90days') {
+      expiresAt = dayjs().add(90, 'day').toISOString()
+    } else if (expirationOption.value === '1year') {
+      expiresAt = dayjs().add(1, 'year').toISOString()
+    } else if (expirationOption.value === 'custom' && customExpiration.value) {
+      expiresAt = dayjs(customExpiration.value).toISOString()
+    }
+
+    const result = await dataService.createApiToken({
+      name: form.value.name,
+      scopes: form.value.scopes,
+      expiresAt: expiresAt
+    })
+    
+    // Show the raw token
+    createdRawToken.value = result.rawToken
+    showCreateModal.value = false
+    showTokenModal.value = true
+    
+    // Reset form
+    form.value = { name: '', scopes: [], expiresAt: undefined }
+    expirationOption.value = 'never'
+    customExpiration.value = ''
+    
+    // Reload tokens list
+    await loadTokens()
+    
+    ObjectUtils.toast(oruga, "success", t('api_tokens.created'), 4000)
+  } catch (err: any) {
+    console.log('error creating token', err)
+    ObjectUtils.toast(oruga, "danger", t('api_tokens.create_error'), 4000)
+  }
+}
+
+async function revokeToken(token: ApiToken) {
+  if (!confirm(t('api_tokens.revoke_confirm', { name: token.name }))) {
+    return
+  }
+  
+  try {
+    await dataService.deleteApiToken(token.id)
+    await loadTokens()
+    ObjectUtils.toast(oruga, "success", t('api_tokens.revoked'), 4000)
+  } catch (err: any) {
+    console.log('error revoking token', err)
+    ObjectUtils.toast(oruga, "danger", t('api_tokens.revoke_error'), 4000)
+  }
+}
+
+async function toggleTokenActive(token: ApiToken) {
+  try {
+    await dataService.updateApiToken(token.id, { isActive: !token.isActive })
+    await loadTokens()
+    ObjectUtils.toast(oruga, "success", token.isActive ? t('api_tokens.deactivated') : t('api_tokens.activated'), 4000)
+  } catch (err: any) {
+    console.log('error updating token', err)
+    ObjectUtils.toast(oruga, "danger", t('api_tokens.update_error'), 4000)
+  }
+}
+
+function copyToken() {
+  navigator.clipboard.writeText(createdRawToken.value)
+  ObjectUtils.toast(oruga, "success", t('api_tokens.copied'), 2000)
+}
+
+function closeTokenModal() {
+  showTokenModal.value = false
+  createdRawToken.value = ''
+}
+
+function formatDate(dateStr: string | undefined) {
+  if (!dateStr) return '-'
+  return dayjs(dateStr).format('YYYY-MM-DD HH:mm')
+}
+
+function formatScopes(scopeList: string[]) {
+  return scopeList.join(', ')
+}
+
+const isFormValid = computed(() => {
+  return form.value.name.length >= 1 && form.value.scopes.length >= 1
+})
+
+const scopesByCategory = computed(() => {
+  const grouped: Record<string, TokenScope[]> = {}
+  for (const scope of scopes.value) {
+    if (!grouped[scope.category]) {
+      grouped[scope.category] = []
+    }
+    grouped[scope.category].push(scope)
+  }
+  return grouped
+})
+
+function toggleScope(scopeName: string) {
+  const idx = form.value.scopes.indexOf(scopeName)
+  if (idx >= 0) {
+    form.value.scopes.splice(idx, 1)
+  } else {
+    form.value.scopes.push(scopeName)
+  }
+}
+
+</script>
+
+<template>
+  <div class="grid grid-cols-1 justify-center justify-items-center justify-self-center">
+    <h1 class="typewriter text-2xl mb-3 capitalize">
+      {{ t('api_tokens.title') }}
+    </h1>
+    
+    <p class="text-base-content/70 mb-4 max-w-2xl text-center">
+      {{ t('api_tokens.description') }}
+    </p>
+
+    <button
+      class="btn btn-primary mb-6"
+      @click="showCreateModal = true"
+    >
+      <i class="bx bx-plus mr-2" />
+      {{ t('api_tokens.create') }}
+    </button>
+
+    <!-- Tokens list -->
+    <div class="w-full max-w-4xl">
+      <div v-if="loading" class="flex justify-center">
+        <span class="loading loading-spinner loading-lg" />
+      </div>
+      
+      <div v-else-if="tokens.length === 0" class="text-center text-base-content/60">
+        {{ t('api_tokens.no_tokens') }}
+      </div>
+      
+      <div v-else class="space-y-4">
+        <div
+          v-for="token in tokens"
+          :key="token.id"
+          class="card bg-base-200 shadow-md"
+        >
+          <div class="card-body">
+            <div class="flex justify-between items-start">
+              <div>
+                <h3 class="card-title">
+                  {{ token.name }}
+                  <span
+                    v-if="!token.isActive"
+                    class="badge badge-warning ml-2"
+                  >
+                    {{ t('api_tokens.inactive') }}
+                  </span>
+                  <span
+                    v-if="token.expiresAt && dayjs(token.expiresAt).isBefore(dayjs())"
+                    class="badge badge-error ml-2"
+                  >
+                    {{ t('api_tokens.expired') }}
+                  </span>
+                </h3>
+                <p class="text-sm text-base-content/70">
+                  {{ t('api_tokens.scopes') }}: {{ formatScopes(token.scopes) }}
+                </p>
+              </div>
+              <div class="flex gap-2">
+                <button
+                  class="btn btn-sm btn-ghost"
+                  :title="token.isActive ? t('api_tokens.deactivate') : t('api_tokens.activate')"
+                  @click="toggleTokenActive(token)"
+                >
+                  <i :class="token.isActive ? 'bx bx-pause' : 'bx bx-play'" />
+                </button>
+                <button
+                  class="btn btn-sm btn-ghost btn-error"
+                  :title="t('api_tokens.revoke')"
+                  @click="revokeToken(token)"
+                >
+                  <i class="bx bx-trash" />
+                </button>
+              </div>
+            </div>
+            
+            <div class="flex flex-wrap gap-4 text-sm text-base-content/60 mt-2">
+              <span>
+                <i class="bx bx-calendar mr-1" />
+                {{ t('api_tokens.created_at') }}: {{ formatDate(token.createdAt) }}
+              </span>
+              <span>
+                <i class="bx bx-time mr-1" />
+                {{ t('api_tokens.last_used') }}: {{ formatDate(token.lastUsedAt) }}
+              </span>
+              <span>
+                <i class="bx bx-bar-chart mr-1" />
+                {{ t('api_tokens.usage_count') }}: {{ token.usageCount }}
+              </span>
+              <span v-if="token.expiresAt">
+                <i class="bx bx-calendar-x mr-1" />
+                {{ t('api_tokens.expires_at') }}: {{ formatDate(token.expiresAt) }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Token Modal -->
+    <div v-if="showCreateModal" class="modal modal-open">
+      <div class="modal-box max-w-2xl">
+        <h3 class="font-bold text-lg mb-4">
+          {{ t('api_tokens.create_new') }}
+        </h3>
+        
+        <div class="form-control mb-4">
+          <label class="label">
+            <span class="label-text">{{ t('api_tokens.token_name') }}</span>
+          </label>
+          <input
+            v-model="form.name"
+            type="text"
+            class="input input-bordered"
+            :placeholder="t('api_tokens.name_placeholder')"
+          >
+        </div>
+
+        <div class="form-control mb-4">
+          <label class="label">
+            <span class="label-text">{{ t('api_tokens.select_scopes') }}</span>
+          </label>
+          <div class="space-y-4">
+            <div v-for="(categoryScopes, category) in scopesByCategory" :key="category">
+              <h4 class="font-semibold text-sm mb-2">{{ category }}</h4>
+              <div class="flex flex-wrap gap-2">
+                <label
+                  v-for="scope in categoryScopes"
+                  :key="scope.name"
+                  class="cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm mr-1"
+                    :checked="form.scopes.includes(scope.name)"
+                    @change="toggleScope(scope.name)"
+                  >
+                  <span class="text-sm" :title="scope.description">
+                    {{ scope.name }}
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-control mb-4">
+          <label class="label">
+            <span class="label-text">{{ t('api_tokens.expiration') }}</span>
+          </label>
+          <select v-model="expirationOption" class="select select-bordered">
+            <option value="never">{{ t('api_tokens.never_expires') }}</option>
+            <option value="30days">{{ t('api_tokens.expires_30days') }}</option>
+            <option value="90days">{{ t('api_tokens.expires_90days') }}</option>
+            <option value="1year">{{ t('api_tokens.expires_1year') }}</option>
+            <option value="custom">{{ t('api_tokens.expires_custom') }}</option>
+          </select>
+          <input
+            v-if="expirationOption === 'custom'"
+            v-model="customExpiration"
+            type="date"
+            class="input input-bordered mt-2"
+          >
+        </div>
+
+        <div class="modal-action">
+          <button class="btn" @click="showCreateModal = false">
+            {{ t('labels.cancel') }}
+          </button>
+          <button
+            class="btn btn-primary"
+            :disabled="!isFormValid"
+            @click="createToken"
+          >
+            {{ t('api_tokens.create') }}
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" @click="showCreateModal = false" />
+    </div>
+
+    <!-- Token Created Modal (shows raw token once) -->
+    <div v-if="showTokenModal" class="modal modal-open">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">
+          {{ t('api_tokens.token_created') }}
+        </h3>
+        
+        <div class="alert alert-warning mb-4">
+          <i class="bx bx-error-circle" />
+          <span>{{ t('api_tokens.copy_warning') }}</span>
+        </div>
+
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">{{ t('api_tokens.your_token') }}</span>
+          </label>
+          <div class="flex gap-2">
+            <input
+              :value="createdRawToken"
+              type="text"
+              class="input input-bordered flex-1 font-mono text-sm"
+              readonly
+            >
+            <button class="btn btn-primary" @click="copyToken">
+              <i class="bx bx-copy" />
+            </button>
+          </div>
+        </div>
+
+        <div class="modal-action">
+          <button class="btn btn-primary" @click="closeTokenModal">
+            {{ t('api_tokens.done') }}
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" @click="closeTokenModal" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+</style>

--- a/src/jelu-ui/src/locales/en.json
+++ b/src/jelu-ui/src/locales/en.json
@@ -97,6 +97,7 @@
       "yes" : "Yes",
       "no" : "No",
       "do_nothing" : "Do nothing",
+      "cancel" : "Cancel",
       "add" : "Add",
       "add_to_my_books" : "Not yet in your books, click to add it",
       "add_translator": "Add a translator",
@@ -152,7 +153,8 @@
         "shelves_max_number_reached" : "Maximum number of shelves is reached. Delete existing ones to add more.",
         "shelf_choose_tag" : "Pick a tag to create the corresponding shelf",
         "custom_lists" : "custom lists",
-        "choose_currency": "Select your currency"
+        "choose_currency": "Select your currency",
+        "api_tokens" : "API Tokens"
     },
     "user" : {
         "log_first" : "Please log in first"
@@ -421,5 +423,45 @@
         "empty" : "list is empty",
         "edit_list" : "edit the list",
         "update_list" : "update the list"
+    },
+    "api_tokens" : {
+        "title" : "API Tokens",
+        "description" : "Create API tokens to enable programmatic access to the Jelu API. Tokens can be used for automation scripts, third-party integrations, and CI/CD pipelines.",
+        "create" : "Create Token",
+        "create_new" : "Create New API Token",
+        "no_tokens" : "No API tokens yet. Create one to get started.",
+        "token_name" : "Token Name",
+        "name_placeholder" : "e.g., Backup Script, Home Assistant",
+        "select_scopes" : "Select Scopes",
+        "expiration" : "Expiration",
+        "never_expires" : "Never expires",
+        "expires_30days" : "30 days",
+        "expires_90days" : "90 days",
+        "expires_1year" : "1 year",
+        "expires_custom" : "Custom date",
+        "created" : "API token created successfully",
+        "create_error" : "Failed to create API token",
+        "token_created" : "Token Created",
+        "copy_warning" : "Make sure to copy your token now. You won't be able to see it again!",
+        "your_token" : "Your Token",
+        "copied" : "Token copied to clipboard",
+        "done" : "Done",
+        "scopes" : "Scopes",
+        "created_at" : "Created",
+        "last_used" : "Last used",
+        "usage_count" : "Uses",
+        "expires_at" : "Expires",
+        "inactive" : "Inactive",
+        "expired" : "Expired",
+        "activate" : "Activate",
+        "deactivate" : "Deactivate",
+        "activated" : "Token activated",
+        "deactivated" : "Token deactivated",
+        "revoke" : "Revoke",
+        "revoke_confirm" : "Are you sure you want to revoke the token '{name}'? This action cannot be undone.",
+        "revoked" : "Token revoked successfully",
+        "revoke_error" : "Failed to revoke token",
+        "load_error" : "Failed to load API tokens",
+        "update_error" : "Failed to update token"
     }
 }

--- a/src/jelu-ui/src/model/ApiToken.ts
+++ b/src/jelu-ui/src/model/ApiToken.ts
@@ -1,0 +1,47 @@
+export interface ApiToken {
+    id: string,
+    userId: string,
+    name: string,
+    scopes: string[],
+    createdAt: string,
+    lastUsedAt?: string,
+    usageCount: number,
+    expiresAt?: string,
+    isActive: boolean
+}
+
+export interface CreateApiToken {
+    name: string,
+    scopes: string[],
+    expiresAt?: string
+}
+
+export interface UpdateApiToken {
+    name?: string,
+    scopes?: string[],
+    isActive?: boolean
+}
+
+export interface ApiTokenCreated {
+    token: ApiToken,
+    rawToken: string
+}
+
+export interface TokenScope {
+    name: string,
+    description: string,
+    category: string
+}
+
+export interface AdminApiToken {
+    id: string,
+    userId: string,
+    userLogin: string,
+    name: string,
+    scopes: string[],
+    createdAt: string,
+    lastUsedAt?: string,
+    usageCount: number,
+    expiresAt?: string,
+    isActive: boolean
+}

--- a/src/jelu-ui/src/router.ts
+++ b/src/jelu-ui/src/router.ts
@@ -148,6 +148,7 @@ const router = createRouter({
                 { path: 'stats', component: () => import(/* webpackChunkName: "recommend" */ './components/UserStats.vue')},
                 { path: 'tags', component: () => import(/* webpackChunkName: "recommend" */ './components/TagsAdmin.vue')},
                 { path: 'data', component: () => import(/* webpackChunkName: "recommend" */ './components/DataAdmin.vue')},
+                { path: 'api-tokens', component: () => import(/* webpackChunkName: "recommend" */ './components/ApiTokens.vue')},
             ]
         },
     ],

--- a/src/jelu-ui/src/services/DataService.ts
+++ b/src/jelu-ui/src/services/DataService.ts
@@ -28,6 +28,7 @@ import { BookQuote, CreateBookQuoteDto, UpdateBookQuoteDto } from "../model/Book
 import urls from "../urls";
 import { OAuth2ClientDto } from "../model/oauth-client-dto";
 import { CustomList, CustomListRemoveDto } from "../model/custom-list";
+import { AdminApiToken, ApiToken, ApiTokenCreated, CreateApiToken, TokenScope, UpdateApiToken } from "../model/ApiToken";
 
 class DataService {
 
@@ -2062,6 +2063,127 @@ class DataService {
       }
       console.log("error remove from list " + (error as AxiosError).code)
       throw new Error("error remove from list " + error)
+    }
+  }
+
+  /*
+   * API Token methods
+   */
+  getApiTokens = async () => {
+    try {
+      const response = await this.apiClient.get<Array<ApiToken>>('/api-tokens');
+      console.log("called api tokens")
+      console.log(response)
+      return response.data;
+    }
+    catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        console.log("error axios " + error.response.status + " " + error.response.data.error)
+      }
+      console.log("error api tokens " + (error as AxiosError).code)
+      throw new Error("error api tokens " + error)
+    }
+  }
+
+  createApiToken = async (token: CreateApiToken) => {
+    try {
+      const resp = await this.apiClient.post<ApiTokenCreated>('/api-tokens', token)
+      console.log("create api token")
+      console.log(resp.data)
+      return resp.data
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        console.log("error create api token " + error.response.status + " " + error.response.data)
+        throw new Error("Error ! " + error.response.data.message)
+      }
+      console.log("error create api token " + (error as AxiosError).code)
+      throw new Error("error create api token " + error)
+    }
+  }
+
+  updateApiToken = async (tokenId: string, token: UpdateApiToken) => {
+    try {
+      const resp = await this.apiClient.put<ApiToken>(`/api-tokens/${tokenId}`, token)
+      console.log("update api token")
+      console.log(resp.data)
+      return resp.data
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        console.log("error update api token " + error.response.status + " " + error.response.data)
+        throw new Error("Error ! " + error.response.data.message)
+      }
+      console.log("error update api token " + (error as AxiosError).code)
+      throw new Error("error update api token " + error)
+    }
+  }
+
+  deleteApiToken = async (tokenId: string) => {
+    try {
+      const response = await this.apiClient.delete(`/api-tokens/${tokenId}`);
+      console.log("delete api token")
+      console.log(response)
+      return response.data;
+    }
+    catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        console.log("error axios " + error.response.status + " " + error.response.data.error)
+      }
+      console.log("error delete api token " + (error as AxiosError).code)
+      throw new Error("error delete api token " + error)
+    }
+  }
+
+  getApiTokenScopes = async () => {
+    try {
+      const response = await this.apiClient.get<Array<TokenScope>>('/api-tokens/scopes');
+      console.log("called api token scopes")
+      console.log(response)
+      return response.data;
+    }
+    catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        console.log("error axios " + error.response.status + " " + error.response.data.error)
+      }
+      console.log("error api token scopes " + (error as AxiosError).code)
+      throw new Error("error api token scopes " + error)
+    }
+  }
+
+  /*
+   * Currently these admin calls are not ever leveraged by the frontend. However, I'm leaving
+   * them here for posterity to allow for an admin interface to potentially be created that
+   * would allow admins control over all API tokens (not just user specific ones) for their
+   * administered Jelu instance.
+   */
+  getAdminApiTokens = async () => {
+    try {
+      const response = await this.apiClient.get<Array<AdminApiToken>>('/admin/api-tokens');
+      console.log("called admin api tokens")
+      console.log(response)
+      return response.data;
+    }
+    catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        console.log("error axios " + error.response.status + " " + error.response.data.error)
+      }
+      console.log("error admin api tokens " + (error as AxiosError).code)
+      throw new Error("error admin api tokens " + error)
+    }
+  }
+
+  adminDeleteApiToken = async (tokenId: string) => {
+    try {
+      const response = await this.apiClient.delete(`/admin/api-tokens/${tokenId}`);
+      console.log("admin delete api token")
+      console.log(response)
+      return response.data;
+    }
+    catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        console.log("error axios " + error.response.status + " " + error.response.data.error)
+      }
+      console.log("error admin delete api token " + (error as AxiosError).code)
+      throw new Error("error admin delete api token " + error)
     }
   }
 

--- a/src/main/kotlin/io/github/bayang/jelu/config/GlobalConfig.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/config/GlobalConfig.kt
@@ -53,8 +53,10 @@ class GlobalConfig {
                         if (jeluProperties.cors.allowedOrigins.isNullOrEmpty()) listOf("*") else jeluProperties.cors.allowedOrigins
                     allowedMethods = HttpMethod.values().map { it.name() }
                     allowCredentials = true
+                    addAllowedHeader(HttpHeaders.AUTHORIZATION)
                     addExposedHeader(HttpHeaders.CONTENT_DISPOSITION)
                     addExposedHeader(SESSION_HEADER_NAME)
+                    addExposedHeader(HttpHeaders.AUTHORIZATION)
                 },
             )
         }

--- a/src/main/kotlin/io/github/bayang/jelu/config/SecurityConfig.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package io.github.bayang.jelu.config
 
+import io.github.bayang.jelu.security.BearerTokenAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -31,6 +32,7 @@ class SecurityConfig(
     private val userDetailsService: UserDetailsService,
     private val passwordEncoder: PasswordEncoder,
     private val authHeaderFilter: AuthHeaderFilter?,
+    private val bearerTokenAuthenticationFilter: BearerTokenAuthenticationFilter,
     private val userAgentWebAuthenticationDetailsSource: WebAuthenticationDetailsSource,
     private val oauth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
     private val oidcUserService: OAuth2UserService<OidcUserRequest, OidcUser>,
@@ -65,6 +67,7 @@ class SecurityConfig(
                         "/api/v1/oauth2/providers",
                         "/api/v1/username/**",
                         "/api/v1/custom-lists/remove",
+                        "/api/v1/api-tokens/scopes",
                     ).permitAll()
                 it.requestMatchers(HttpMethod.GET, "/api/v1/reviews/**").permitAll()
                 it.requestMatchers(HttpMethod.GET, "/api/v1/reviews").permitAll()
@@ -100,6 +103,8 @@ class SecurityConfig(
             }.sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
             }
+        // Add Bearer token authentication filter (always enabled)
+        http.addFilterBefore(bearerTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
         if (properties.auth.ldap.enabled) {
             val dao = DaoAuthenticationProvider()
             dao.setUserDetailsService(userDetailsService)

--- a/src/main/kotlin/io/github/bayang/jelu/config/SessionConfig.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/config/SessionConfig.kt
@@ -2,6 +2,8 @@ package io.github.bayang.jelu.config
 
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.bayang.jelu.security.ApiTokenAuthentication
+import io.github.bayang.jelu.security.ApiTokenAuthenticationMixin
 import org.springframework.beans.factory.BeanClassLoaderAware
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -84,6 +86,7 @@ class SessionConfig : BeanClassLoaderAware {
         copy.registerModules(SecurityJackson2Modules.getModules(this.classLoader))
         copy.disable(MapperFeature.USE_GETTERS_AS_SETTERS) // mandatory to deserialize setterless authorities on user
         copy.addMixIn(UserAgentWebAuthenticationDetails::class.java, UserAgentWebAuthenticationDetailsMixin::class.java)
+        copy.addMixIn(ApiTokenAuthentication::class.java, ApiTokenAuthenticationMixin::class.java)
         val converter = GenericConversionService()
         converter.addConverter(Any::class.java, ByteArray::class.java, SerializingConverter(JsonSerializer(copy)))
         converter.addConverter(ByteArray::class.java, Any::class.java, DeserializingConverter(JsonDeserializer(copy)))

--- a/src/main/kotlin/io/github/bayang/jelu/controllers/ApiTokenController.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/controllers/ApiTokenController.kt
@@ -1,0 +1,132 @@
+package io.github.bayang.jelu.controllers
+
+import io.github.bayang.jelu.dto.AdminApiTokenDto
+import io.github.bayang.jelu.dto.ApiTokenCreatedDto
+import io.github.bayang.jelu.dto.ApiTokenDto
+import io.github.bayang.jelu.dto.CreateApiTokenDto
+import io.github.bayang.jelu.dto.JeluUser
+import io.github.bayang.jelu.dto.TokenScopeDto
+import io.github.bayang.jelu.dto.UpdateApiTokenDto
+import io.github.bayang.jelu.errors.JeluNotFoundException
+import io.github.bayang.jelu.service.ApiTokenService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1")
+@Tag(name = "API Tokens", description = "Manage API tokens for programmatic access")
+class ApiTokenController(
+    private val apiTokenService: ApiTokenService,
+) {
+    @Operation(summary = "List user's API tokens")
+    @GetMapping(path = ["/api-tokens"])
+    fun listTokens(principal: Authentication): List<ApiTokenDto> {
+        val user = (principal.principal as JeluUser).user
+        return apiTokenService.findByUserId(user.id!!)
+    }
+
+    @Operation(summary = "Create a new API token")
+    @ApiResponse(responseCode = "201", description = "Token created successfully")
+    @PostMapping(path = ["/api-tokens"])
+    fun createToken(
+        @RequestBody @Valid createDto: CreateApiTokenDto,
+        principal: Authentication,
+    ): ResponseEntity<ApiTokenCreatedDto> {
+        val user = (principal.principal as JeluUser).user
+        val createdToken = apiTokenService.createToken(createDto, user.id!!)
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdToken)
+    }
+
+    @Operation(summary = "Get a specific API token")
+    @GetMapping(path = ["/api-tokens/{id}"])
+    fun getToken(
+        @PathVariable("id") tokenId: UUID,
+        principal: Authentication,
+    ): ApiTokenDto {
+        val user = (principal.principal as JeluUser).user
+        return apiTokenService.findByIdAndUserId(tokenId, user.id!!)
+            ?: throw JeluNotFoundException("Token not found")
+    }
+
+    @Operation(summary = "Update an API token")
+    @PutMapping(path = ["/api-tokens/{id}"])
+    fun updateToken(
+        @PathVariable("id") tokenId: UUID,
+        @RequestBody @Valid updateDto: UpdateApiTokenDto,
+        principal: Authentication,
+    ): ApiTokenDto {
+        val user = (principal.principal as JeluUser).user
+        return apiTokenService.updateToken(tokenId, user.id!!, updateDto)
+            ?: throw JeluNotFoundException("Token not found")
+    }
+
+    @Operation(summary = "Revoke an API token")
+    @ApiResponse(responseCode = "204", description = "Token revoked successfully")
+    @DeleteMapping(path = ["/api-tokens/{id}"])
+    fun revokeToken(
+        @PathVariable("id") tokenId: UUID,
+        principal: Authentication,
+    ): ResponseEntity<Unit> {
+        val user = (principal.principal as JeluUser).user
+        val deleted = apiTokenService.revokeToken(tokenId, user.id!!)
+        return if (deleted) {
+            ResponseEntity.noContent().build()
+        } else {
+            throw JeluNotFoundException("Token not found")
+        }
+    }
+
+    @Operation(summary = "List available scopes")
+    @GetMapping(path = ["/api-tokens/scopes"])
+    fun listScopes(): List<TokenScopeDto> = TokenScopeDto.allScopes()
+
+    /*
+     * Admin endpoints - Are currently not instrumented in the frontend UI, but are preserved here
+     * for future expansion to allow admins to manage all user's API tokens for their instance
+     */
+
+    @Operation(summary = "Admin: List all API tokens")
+    @GetMapping(path = ["/admin/api-tokens"])
+    fun adminListAllTokens(principal: Authentication): List<AdminApiTokenDto> {
+        val user = (principal.principal as JeluUser).user
+        if (!user.isAdmin) {
+            throw org.springframework.security.access
+                .AccessDeniedException("Admin access required")
+        }
+        return apiTokenService.findAll()
+    }
+
+    @Operation(summary = "Admin: Revoke any API token")
+    @ApiResponse(responseCode = "204", description = "Token revoked successfully")
+    @DeleteMapping(path = ["/admin/api-tokens/{id}"])
+    fun adminRevokeToken(
+        @PathVariable("id") tokenId: UUID,
+        principal: Authentication,
+    ): ResponseEntity<Unit> {
+        val user = (principal.principal as JeluUser).user
+        if (!user.isAdmin) {
+            throw org.springframework.security.access
+                .AccessDeniedException("Admin access required")
+        }
+        val deleted = apiTokenService.revokeToken(tokenId, user.id!!, isAdmin = true)
+        return if (deleted) {
+            ResponseEntity.noContent().build()
+        } else {
+            throw JeluNotFoundException("Token not found")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/bayang/jelu/controllers/GlobalControllerExceptionHandler.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/controllers/GlobalControllerExceptionHandler.kt
@@ -2,6 +2,7 @@ package io.github.bayang.jelu.controllers
 
 import io.github.bayang.jelu.errors.JeluAuthenticationException
 import io.github.bayang.jelu.errors.JeluException
+import io.github.bayang.jelu.errors.JeluNotFoundException
 import io.github.bayang.jelu.errors.JeluValidationException
 import jakarta.validation.ConstraintViolationException
 import org.jetbrains.exposed.dao.exceptions.EntityNotFoundException
@@ -57,6 +58,11 @@ class GlobalControllerExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
     fun handleJeluValidationException(e: JeluValidationException): ApiError = ApiError(e.message)
+
+    @ExceptionHandler(JeluNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseBody
+    fun handleJeluNotFoundException(e: JeluNotFoundException): ApiError = ApiError(e.message)
 }
 
 data class ApiError(

--- a/src/main/kotlin/io/github/bayang/jelu/controllers/UsersController.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/controllers/UsersController.kt
@@ -178,12 +178,17 @@ class UsersController(
         entry: Map.Entry<String, Session>,
         ctx: SecurityContextImpl?,
     ): LoginHistoryInfoDto {
-        val details = ctx?.authentication?.details as UserAgentWebAuthenticationDetails
-        val jeluUser = ctx.authentication.principal as JeluUser
+        val details = ctx?.authentication?.details as? UserAgentWebAuthenticationDetails
+        val jeluUser = ctx?.authentication?.principal as? JeluUser
         return LoginHistoryInfoDto(
-            ip = details.remoteAddress.orEmpty(),
-            userAgent = details.userAgent,
-            source = jeluUser.user.provider.name,
+            ip = details?.remoteAddress.orEmpty(),
+            userAgent = details?.userAgent.orEmpty(),
+            source =
+                jeluUser
+                    ?.user
+                    ?.provider
+                    ?.name
+                    .orEmpty(),
             date = stringFormat(entry.value.lastAccessedTime),
         )
     }

--- a/src/main/kotlin/io/github/bayang/jelu/dao/ApiTokenRepository.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dao/ApiTokenRepository.kt
@@ -1,0 +1,89 @@
+package io.github.bayang.jelu.dao
+
+import io.github.bayang.jelu.dto.CreateApiTokenDto
+import io.github.bayang.jelu.dto.UpdateApiTokenDto
+import io.github.bayang.jelu.utils.nowInstant
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.selectAll
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+@Repository
+class ApiTokenRepository {
+    fun save(
+        createApiTokenDto: CreateApiTokenDto,
+        tokenHash: String,
+        userId: UUID,
+    ): ApiToken {
+        val instant: Instant = nowInstant()
+        return ApiToken.new {
+            this.user = User[userId]
+            this.tokenHash = tokenHash
+            this.name = createApiTokenDto.name
+            this.scopes = createApiTokenDto.scopes.joinToString(",")
+            this.createdAt = instant
+            this.expiresAt = createApiTokenDto.expiresAt
+            this.isActive = true
+            this.usageCount = 0
+        }
+    }
+
+    fun findByTokenHash(tokenHash: String): ApiToken? {
+        val query =
+            ApiTokenTable
+                .selectAll()
+                .andWhere { ApiTokenTable.tokenHash eq tokenHash }
+        return ApiToken.wrapRows(query).firstOrNull()
+    }
+
+    fun findByUserId(userId: UUID): List<ApiToken> {
+        val query =
+            ApiTokenTable
+                .selectAll()
+                .andWhere { ApiTokenTable.userId eq userId }
+        return ApiToken.wrapRows(query).toList()
+    }
+
+    fun findAll(): List<ApiToken> = ApiToken.all().toList()
+
+    fun findById(id: UUID): ApiToken? = ApiToken.findById(id)
+
+    fun update(
+        id: UUID,
+        updateDto: UpdateApiTokenDto,
+    ): ApiToken? {
+        val token = ApiToken.findById(id) ?: return null
+        updateDto.name?.let { token.name = it }
+        updateDto.scopes?.let { token.scopes = it.joinToString(",") }
+        updateDto.isActive?.let { token.isActive = it }
+        return token
+    }
+
+    fun updateLastUsed(id: UUID) {
+        val token = ApiToken.findById(id)
+        token?.let {
+            it.lastUsedAt = nowInstant()
+            it.usageCount = it.usageCount + 1
+        }
+    }
+
+    fun delete(id: UUID): Boolean {
+        val token = ApiToken.findById(id)
+        return if (token != null) {
+            token.delete()
+            true
+        } else {
+            false
+        }
+    }
+
+    fun deleteByUserId(userId: UUID): Int {
+        val tokens = findByUserId(userId)
+        tokens.forEach { it.delete() }
+        return tokens.size
+    }
+}

--- a/src/main/kotlin/io/github/bayang/jelu/dao/ApiTokenTable.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dao/ApiTokenTable.kt
@@ -1,0 +1,51 @@
+package io.github.bayang.jelu.dao
+
+import io.github.bayang.jelu.dto.ApiTokenDto
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.javatime.timestamp
+import java.util.UUID
+
+object ApiTokenTable : UUIDTable("api_token") {
+    val userId = reference("user_id", UserTable, onDelete = ReferenceOption.CASCADE)
+    val tokenHash = varchar("token_hash", 64).uniqueIndex()
+    val name = varchar("name", 100)
+    val scopes = varchar("scopes", 500)
+    val createdAt = timestamp("created_at")
+    val lastUsedAt = timestamp("last_used_at").nullable()
+    val usageCount = long("usage_count").default(0)
+    val expiresAt = timestamp("expires_at").nullable()
+    val isActive = bool("is_active").default(true)
+}
+
+class ApiToken(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<ApiToken>(ApiTokenTable)
+
+    var user by User referencedOn ApiTokenTable.userId
+    var tokenHash by ApiTokenTable.tokenHash
+    var name by ApiTokenTable.name
+    var scopes by ApiTokenTable.scopes
+    var createdAt by ApiTokenTable.createdAt
+    var lastUsedAt by ApiTokenTable.lastUsedAt
+    var usageCount by ApiTokenTable.usageCount
+    var expiresAt by ApiTokenTable.expiresAt
+    var isActive by ApiTokenTable.isActive
+
+    fun toApiTokenDto(): ApiTokenDto =
+        ApiTokenDto(
+            id = this.id.value,
+            userId = this.user.id.value,
+            name = this.name,
+            scopes = this.scopes.split(",").filter { it.isNotBlank() },
+            createdAt = this.createdAt,
+            lastUsedAt = this.lastUsedAt,
+            usageCount = this.usageCount,
+            expiresAt = this.expiresAt,
+            isActive = this.isActive,
+        )
+}

--- a/src/main/kotlin/io/github/bayang/jelu/dto/ApiTokenDto.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dto/ApiTokenDto.kt
@@ -1,0 +1,98 @@
+package io.github.bayang.jelu.dto
+
+import io.github.bayang.jelu.security.TokenScope
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * DTO for API token responses (does not include the token hash)
+ */
+data class ApiTokenDto(
+    val id: UUID,
+    val userId: UUID,
+    val name: String,
+    val scopes: List<String>,
+    val createdAt: Instant,
+    val lastUsedAt: Instant?,
+    val usageCount: Long,
+    val expiresAt: Instant?,
+    val isActive: Boolean,
+)
+
+/**
+ * DTO for creating a new API token
+ */
+data class CreateApiTokenDto(
+    @field:NotBlank(message = "Token name is required")
+    @field:Size(max = 100, message = "Token name must be at most 100 characters")
+    val name: String,
+    @field:Size(min = 1, message = "At least one scope is required")
+    val scopes: List<String>,
+    val expiresAt: Instant? = null,
+)
+
+/**
+ * DTO for updating an existing API token
+ */
+data class UpdateApiTokenDto(
+    @field:Size(max = 100, message = "Token name must be at most 100 characters")
+    val name: String? = null,
+    val scopes: List<String>? = null,
+    val isActive: Boolean? = null,
+)
+
+/**
+ * Response DTO that includes the raw token (only returned once on creation)
+ */
+data class ApiTokenCreatedDto(
+    val token: ApiTokenDto,
+    val rawToken: String,
+)
+
+/**
+ * DTO for listing available scopes
+ */
+data class TokenScopeDto(
+    val name: String,
+    val description: String,
+    val category: String,
+) {
+    companion object {
+        fun fromTokenScope(scope: TokenScope): TokenScopeDto =
+            TokenScopeDto(
+                name = scope.scopeName,
+                description = scope.description,
+                category = scope.category.displayName,
+            )
+
+        fun allScopes(): List<TokenScopeDto> = TokenScope.entries.map { fromTokenScope(it) }
+    }
+}
+
+/**
+ * DTO for admin view of tokens (includes user info)
+ */
+data class AdminApiTokenDto(
+    val id: UUID,
+    val userId: UUID,
+    val userLogin: String,
+    val name: String,
+    val scopes: List<String>,
+    val createdAt: Instant,
+    val lastUsedAt: Instant?,
+    val usageCount: Long,
+    val expiresAt: Instant?,
+    val isActive: Boolean,
+)
+
+/**
+ * DTO for validated API token (includes full user data for authentication)
+ */
+data class ValidatedApiTokenDto(
+    val id: UUID,
+    val name: String,
+    val scopes: List<String>,
+    val user: UserDto,
+)

--- a/src/main/kotlin/io/github/bayang/jelu/errors/JeluNotFoundException.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/errors/JeluNotFoundException.kt
@@ -1,0 +1,8 @@
+package io.github.bayang.jelu.errors
+
+class JeluNotFoundException : Exception {
+    constructor() : super()
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(cause: Throwable) : super(cause)
+}

--- a/src/main/kotlin/io/github/bayang/jelu/security/BearerTokenAuthenticationFilter.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/security/BearerTokenAuthenticationFilter.kt
@@ -1,0 +1,201 @@
+package io.github.bayang.jelu.security
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.github.bayang.jelu.dto.JeluUser
+import io.github.bayang.jelu.service.ApiTokenService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+const val BEARER_PREFIX = "Bearer "
+
+/**
+ * Filter that processes Bearer token authentication for API tokens.
+ * This filter:
+ * 1. Extracts the Bearer token from the Authorization header
+ * 2. Validates the token against the database
+ * 3. Creates an authentication with the token's scopes as authorities
+ * 4. Updates last used timestamp asynchronously
+ */
+@Component
+class BearerTokenAuthenticationFilter(
+    private val apiTokenService: ApiTokenService,
+) : OncePerRequestFilter() {
+    // Use request-attribute based context repository to avoid session storage
+    private val securityContextRepository = RequestAttributeSecurityContextRepository()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        // Only process if no authentication is already set
+        if (SecurityContextHolder.getContext().authentication != null) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val authHeader = request.getHeader(HttpHeaders.AUTHORIZATION)
+
+        // Check if this is a Bearer token request
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val rawToken = authHeader.removePrefix(BEARER_PREFIX).trim()
+
+        if (rawToken.isBlank()) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        try {
+            val validatedToken = apiTokenService.validateToken(rawToken)
+
+            if (validatedToken != null) {
+                // Build authorities from scopes + base USER role
+                val authorities = buildAuthorities(validatedToken.scopes)
+
+                // Create JeluUser from the token's user
+                val jeluUser = JeluUser(validatedToken.user)
+
+                // Create authentication
+                val authentication =
+                    ApiTokenAuthentication(
+                        principal = jeluUser,
+                        credentials = null,
+                        authorities = authorities,
+                        tokenId = validatedToken.id,
+                        tokenName = validatedToken.name,
+                        scopes = validatedToken.scopes,
+                    )
+
+                // Create a new security context and set it (don't persist to session)
+                val securityContext = SecurityContextHolder.createEmptyContext()
+                securityContext.authentication = authentication
+                SecurityContextHolder.setContext(securityContext)
+
+                // Save context to request attributes only (not to session)
+                securityContextRepository.saveContext(securityContext, request, response)
+
+                logger.debug { "Authenticated via API token '${validatedToken.name}' for user '${jeluUser.username}'" }
+
+                // Update last used asynchronously
+                apiTokenService.updateLastUsedAsync(validatedToken.id)
+
+                // Check scope access for this request
+                val path = request.requestURI
+                val method = request.method
+
+                if (!ScopePathMatcher.hasRequiredScope(path, method, validatedToken.scopes)) {
+                    logger.debug { "Token '${validatedToken.name}' lacks required scope for $method $path" }
+                    response.sendError(
+                        HttpServletResponse.SC_FORBIDDEN,
+                        "Insufficient scope for this operation",
+                    )
+                    return
+                }
+
+                // Token is valid and has required scope, continue with filter chain
+                filterChain.doFilter(request, response)
+                return
+            } else {
+                // Bearer token was provided but is invalid/inactive/expired
+                logger.debug { "Invalid or expired API token" }
+                response.sendError(
+                    HttpServletResponse.SC_UNAUTHORIZED,
+                    "Invalid or expired API token",
+                )
+                return
+            }
+        } catch (e: Exception) {
+            logger.warn { "Error validating API token: ${e.message}" }
+            response.sendError(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "Error validating API token",
+            )
+            return
+        }
+    }
+
+    private fun buildAuthorities(scopes: List<String>): List<GrantedAuthority> {
+        val authorities = mutableListOf<GrantedAuthority>()
+
+        // Add base USER role
+        authorities.add(SimpleGrantedAuthority("ROLE_USER"))
+
+        // Add scope-based authorities
+        authorities.addAll(TokenScope.toGrantedAuthorities(scopes))
+
+        return authorities
+    }
+}
+
+/**
+ * Custom authentication class for API token authenticated requests.
+ * Extends UsernamePasswordAuthenticationToken but includes token-specific metadata.
+ */
+class ApiTokenAuthentication(
+    principal: JeluUser,
+    credentials: Any?,
+    authorities: Collection<GrantedAuthority>,
+    val tokenId: UUID,
+    val tokenName: String,
+    val scopes: List<String>,
+) : UsernamePasswordAuthenticationToken(principal, credentials, authorities) {
+    /**
+     * Check if this authentication has a specific scope
+     */
+    fun hasScope(scope: String): Boolean = scopes.contains(scope)
+
+    /**
+     * Check if this authentication has any of the specified scopes
+     */
+    fun hasAnyScope(vararg requiredScopes: String): Boolean = requiredScopes.any { it in scopes }
+
+    /**
+     * Check if this authentication has all of the specified scopes
+     */
+    fun hasAllScopes(vararg requiredScopes: String): Boolean = requiredScopes.all { it in scopes }
+}
+
+/**
+ * Jackson mixin for ApiTokenAuthentication to support session serialization.
+ * This is needed when sessions contain ApiTokenAuthentication objects that need
+ * to be serialized/deserialized from the session store.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(
+    fieldVisibility = JsonAutoDetect.Visibility.ANY,
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    creatorVisibility = JsonAutoDetect.Visibility.ANY,
+)
+abstract class ApiTokenAuthenticationMixin
+    @JsonCreator
+    constructor(
+        @JsonProperty("principal") principal: JeluUser,
+        @JsonProperty("credentials") credentials: Any?,
+        @JsonProperty("authorities") authorities: Collection<GrantedAuthority>,
+        @JsonProperty("tokenId") tokenId: UUID,
+        @JsonProperty("tokenName") tokenName: String,
+        @JsonProperty("scopes") scopes: List<String>,
+    )

--- a/src/main/kotlin/io/github/bayang/jelu/security/TokenScope.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/security/TokenScope.kt
@@ -1,0 +1,142 @@
+package io.github.bayang.jelu.security
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+/**
+ * Defines the available scopes for API tokens.
+ * Scopes control what operations a token can perform.
+ */
+enum class TokenScope(
+    val scopeName: String,
+    val description: String,
+    val category: ScopeCategory,
+) {
+    BOOKS_READ("books:read", "View books, authors, tags, series, publishers", ScopeCategory.BOOKS),
+    BOOKS_WRITE("books:write", "Create/modify/delete books and metadata", ScopeCategory.BOOKS),
+    READING_READ("reading:read", "View reading events and statistics", ScopeCategory.READING),
+    READING_WRITE("reading:write", "Create/modify/delete reading events", ScopeCategory.READING),
+    REVIEWS_READ("reviews:read", "View reviews", ScopeCategory.REVIEWS),
+    REVIEWS_WRITE("reviews:write", "Create/modify/delete reviews", ScopeCategory.REVIEWS),
+    LISTS_READ("lists:read", "View custom lists, shelves, quotes", ScopeCategory.LISTS),
+    LISTS_WRITE("lists:write", "Create/modify/delete lists, shelves, quotes", ScopeCategory.LISTS),
+    IMPORT_WRITE("import:write", "Import/export data, browse filesystem", ScopeCategory.IMPORT),
+    METADATA_READ("metadata:read", "Fetch external metadata from providers", ScopeCategory.METADATA),
+    ;
+
+    fun toGrantedAuthority(): GrantedAuthority = SimpleGrantedAuthority("SCOPE_$scopeName")
+
+    companion object {
+        private val scopeNameMap = entries.associateBy { it.scopeName }
+
+        fun fromScopeName(scopeName: String): TokenScope? = scopeNameMap[scopeName]
+
+        fun fromScopeNames(scopeNames: List<String>): List<TokenScope> = scopeNames.mapNotNull { fromScopeName(it) }
+
+        fun toGrantedAuthorities(scopes: List<String>): List<GrantedAuthority> = fromScopeNames(scopes).map { it.toGrantedAuthority() }
+
+        fun allScopeNames(): List<String> = entries.map { it.scopeName }
+
+        fun isValidScope(scopeName: String): Boolean = scopeNameMap.containsKey(scopeName)
+
+        fun validateScopes(scopeNames: List<String>): Boolean = scopeNames.all { isValidScope(it) }
+    }
+}
+
+enum class ScopeCategory(
+    val displayName: String,
+) {
+    BOOKS("Books & Metadata"),
+    READING("Reading Events"),
+    REVIEWS("Reviews"),
+    LISTS("Lists & Shelves"),
+    IMPORT("Import/Export"),
+    METADATA("External Metadata"),
+}
+
+/**
+ * Helper class to check if a request path matches a scope.
+ */
+object ScopePathMatcher {
+    private val pathScopeMap =
+        mapOf(
+            // Books endpoints
+            Pair("/api/v1/books", "GET") to listOf(TokenScope.BOOKS_READ),
+            Pair("/api/v1/books", "POST") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/books", "PUT") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/books", "DELETE") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/authors", "GET") to listOf(TokenScope.BOOKS_READ),
+            Pair("/api/v1/authors", "POST") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/authors", "PUT") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/authors", "DELETE") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/tags", "GET") to listOf(TokenScope.BOOKS_READ),
+            Pair("/api/v1/tags", "POST") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/tags", "PUT") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/tags", "DELETE") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/series", "GET") to listOf(TokenScope.BOOKS_READ),
+            Pair("/api/v1/series", "POST") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/series", "PUT") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/series", "DELETE") to listOf(TokenScope.BOOKS_WRITE),
+            Pair("/api/v1/publishers", "GET") to listOf(TokenScope.BOOKS_READ),
+            // User books (reading events)
+            Pair("/api/v1/userbooks", "GET") to listOf(TokenScope.READING_READ),
+            Pair("/api/v1/userbooks", "POST") to listOf(TokenScope.READING_WRITE),
+            Pair("/api/v1/userbooks", "PUT") to listOf(TokenScope.READING_WRITE),
+            Pair("/api/v1/userbooks", "DELETE") to listOf(TokenScope.READING_WRITE),
+            Pair("/api/v1/reading-events", "GET") to listOf(TokenScope.READING_READ),
+            Pair("/api/v1/reading-events", "POST") to listOf(TokenScope.READING_WRITE),
+            Pair("/api/v1/reading-events", "PUT") to listOf(TokenScope.READING_WRITE),
+            Pair("/api/v1/reading-events", "DELETE") to listOf(TokenScope.READING_WRITE),
+            // Reviews
+            Pair("/api/v1/reviews", "GET") to listOf(TokenScope.REVIEWS_READ),
+            Pair("/api/v1/reviews", "POST") to listOf(TokenScope.REVIEWS_WRITE),
+            Pair("/api/v1/reviews", "PUT") to listOf(TokenScope.REVIEWS_WRITE),
+            Pair("/api/v1/reviews", "DELETE") to listOf(TokenScope.REVIEWS_WRITE),
+            // Lists, shelves, quotes
+            Pair("/api/v1/shelves", "GET") to listOf(TokenScope.LISTS_READ),
+            Pair("/api/v1/shelves", "POST") to listOf(TokenScope.LISTS_WRITE),
+            Pair("/api/v1/shelves", "DELETE") to listOf(TokenScope.LISTS_WRITE),
+            Pair("/api/v1/quotes", "GET") to listOf(TokenScope.LISTS_READ),
+            Pair("/api/v1/quotes", "POST") to listOf(TokenScope.LISTS_WRITE),
+            Pair("/api/v1/quotes", "PUT") to listOf(TokenScope.LISTS_WRITE),
+            Pair("/api/v1/quotes", "DELETE") to listOf(TokenScope.LISTS_WRITE),
+            Pair("/api/v1/custom-lists", "GET") to listOf(TokenScope.LISTS_READ),
+            Pair("/api/v1/custom-lists", "POST") to listOf(TokenScope.LISTS_WRITE),
+            Pair("/api/v1/custom-lists", "PUT") to listOf(TokenScope.LISTS_WRITE),
+            Pair("/api/v1/custom-lists", "DELETE") to listOf(TokenScope.LISTS_WRITE),
+            // Import/Export
+            Pair("/api/v1/imports", "GET") to listOf(TokenScope.IMPORT_WRITE),
+            Pair("/api/v1/imports", "POST") to listOf(TokenScope.IMPORT_WRITE),
+            Pair("/api/v1/files", "GET") to listOf(TokenScope.IMPORT_WRITE),
+            // Metadata
+            Pair("/api/v1/metadata", "GET") to listOf(TokenScope.METADATA_READ),
+            Pair("/api/v1/metadata", "POST") to listOf(TokenScope.METADATA_READ),
+        )
+
+    /**
+     * Check if the given scopes allow access to the specified path and method.
+     * Returns true if access is allowed, false otherwise.
+     */
+    fun hasRequiredScope(
+        path: String,
+        method: String,
+        userScopes: List<String>,
+    ): Boolean {
+        val userTokenScopes = TokenScope.fromScopeNames(userScopes)
+
+        // Find matching path prefix
+        for ((key, requiredScopes) in pathScopeMap) {
+            val (pathPattern, httpMethod) = key
+            if (path.startsWith(pathPattern) && method.equals(httpMethod, ignoreCase = true)) {
+                // Check if user has at least one of the required scopes
+                return requiredScopes.any { it in userTokenScopes }
+            }
+        }
+
+        /*
+         * Default: if path is not in map, deny by default to be secure, this means that paths
+         * MUST be added to the map in order to be useable by an API token
+         */
+        return false
+    }
+}

--- a/src/main/kotlin/io/github/bayang/jelu/service/ApiTokenService.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/service/ApiTokenService.kt
@@ -1,0 +1,231 @@
+package io.github.bayang.jelu.service
+
+import io.github.bayang.jelu.dao.ApiToken
+import io.github.bayang.jelu.dao.ApiTokenRepository
+import io.github.bayang.jelu.dto.AdminApiTokenDto
+import io.github.bayang.jelu.dto.ApiTokenCreatedDto
+import io.github.bayang.jelu.dto.ApiTokenDto
+import io.github.bayang.jelu.dto.CreateApiTokenDto
+import io.github.bayang.jelu.dto.UpdateApiTokenDto
+import io.github.bayang.jelu.dto.ValidatedApiTokenDto
+import io.github.bayang.jelu.errors.JeluValidationException
+import io.github.bayang.jelu.security.TokenScope
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.Instant
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+const val TOKEN_PREFIX = "jelu_"
+const val TOKEN_HEX_LENGTH = 32
+
+@Component
+class ApiTokenService(
+    private val apiTokenRepository: ApiTokenRepository,
+) {
+    private val secureRandom = SecureRandom()
+
+    /**
+     * Generate a new API token with the format: jelu_<32-hex-chars>
+     */
+    fun generateRawToken(): String {
+        val bytes = ByteArray(16)
+        secureRandom.nextBytes(bytes)
+        val hex = bytes.joinToString("") { "%02x".format(it) }
+        return "$TOKEN_PREFIX$hex"
+    }
+
+    /**
+     * Hash a token using SHA-256
+     */
+    fun hashToken(rawToken: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(rawToken.toByteArray(Charsets.UTF_8))
+        return hashBytes.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Validate that a raw token has the correct format
+     */
+    fun isValidTokenFormat(rawToken: String): Boolean {
+        if (!rawToken.startsWith(TOKEN_PREFIX)) return false
+        val hexPart = rawToken.removePrefix(TOKEN_PREFIX)
+        if (hexPart.length != TOKEN_HEX_LENGTH) return false
+        return hexPart.all { it in '0'..'9' || it in 'a'..'f' }
+    }
+
+    @Transactional
+    fun createToken(
+        createDto: CreateApiTokenDto,
+        userId: UUID,
+    ): ApiTokenCreatedDto {
+        // Validate scopes
+        if (!TokenScope.validateScopes(createDto.scopes)) {
+            val invalidScopes = createDto.scopes.filter { !TokenScope.isValidScope(it) }
+            throw JeluValidationException("Invalid scopes: $invalidScopes")
+        }
+
+        // Validate expiration date if provided
+        createDto.expiresAt?.let {
+            if (it.isBefore(Instant.now())) {
+                throw JeluValidationException("Expiration date must be in the future")
+            }
+        }
+
+        // Check if user already has too many tokens (limit to 20)
+        val existingTokens = apiTokenRepository.findByUserId(userId)
+        if (existingTokens.size >= 20) {
+            throw JeluValidationException("Maximum number of API tokens (20) reached")
+        }
+
+        // Generate and hash token
+        val rawToken = generateRawToken()
+        val tokenHash = hashToken(rawToken)
+
+        // Save token
+        val savedToken = apiTokenRepository.save(createDto, tokenHash, userId)
+
+        logger.info { "Created API token '${createDto.name}' for user $userId" }
+
+        return ApiTokenCreatedDto(
+            token = savedToken.toApiTokenDto(),
+            rawToken = rawToken,
+        )
+    }
+
+    @Transactional
+    fun findByUserId(userId: UUID): List<ApiTokenDto> = apiTokenRepository.findByUserId(userId).map { it.toApiTokenDto() }
+
+    @Transactional
+    fun findAll(): List<AdminApiTokenDto> = apiTokenRepository.findAll().map { it.toAdminApiTokenDto() }
+
+    @Transactional
+    fun findById(id: UUID): ApiTokenDto? = apiTokenRepository.findById(id)?.toApiTokenDto()
+
+    @Transactional
+    fun findByIdAndUserId(
+        id: UUID,
+        userId: UUID,
+    ): ApiTokenDto? {
+        val token = apiTokenRepository.findById(id)
+        return if (token != null && token.user.id.value == userId) {
+            token.toApiTokenDto()
+        } else {
+            null
+        }
+    }
+
+    @Transactional
+    fun updateToken(
+        id: UUID,
+        userId: UUID,
+        updateDto: UpdateApiTokenDto,
+        isAdmin: Boolean = false,
+    ): ApiTokenDto? {
+        val token = apiTokenRepository.findById(id) ?: return null
+
+        // Non-admin users can only update their own tokens
+        if (!isAdmin && token.user.id.value != userId) {
+            throw JeluValidationException("You can only update your own tokens")
+        }
+
+        // Validate scopes if provided
+        updateDto.scopes?.let {
+            if (!TokenScope.validateScopes(it)) {
+                val invalidScopes = it.filter { scope -> !TokenScope.isValidScope(scope) }
+                throw JeluValidationException("Invalid scopes: $invalidScopes")
+            }
+        }
+
+        return apiTokenRepository.update(id, updateDto)?.toApiTokenDto()
+    }
+
+    @Transactional
+    fun revokeToken(
+        id: UUID,
+        userId: UUID,
+        isAdmin: Boolean = false,
+    ): Boolean {
+        val token = apiTokenRepository.findById(id) ?: return false
+
+        // Non-admin users can only revoke their own tokens
+        if (!isAdmin && token.user.id.value != userId) {
+            throw JeluValidationException("You can only revoke your own tokens")
+        }
+
+        logger.info { "Revoking API token '${token.name}' (id: $id)" }
+        return apiTokenRepository.delete(id)
+    }
+
+    /**
+     * Validate a raw token and return token details with user info if valid.
+     * All data is loaded within the transaction to avoid lazy loading issues.
+     */
+    @Transactional
+    fun validateToken(rawToken: String): ValidatedApiTokenDto? {
+        if (!isValidTokenFormat(rawToken)) {
+            logger.debug { "Invalid token format" }
+            return null
+        }
+
+        val tokenHash = hashToken(rawToken)
+        val token = apiTokenRepository.findByTokenHash(tokenHash)
+
+        if (token == null) {
+            logger.debug { "Token not found" }
+            return null
+        }
+
+        if (!token.isActive) {
+            logger.debug { "Token is inactive" }
+            return null
+        }
+
+        token.expiresAt?.let {
+            if (it.isBefore(Instant.now())) {
+                logger.debug { "Token has expired" }
+                return null
+            }
+        }
+
+        // Load all required data within the transaction
+        return ValidatedApiTokenDto(
+            id = token.id.value,
+            name = token.name,
+            scopes = token.scopes.split(",").filter { it.isNotBlank() },
+            user = token.user.toUserDto(),
+        )
+    }
+
+    /**
+     * Update last used timestamp asynchronously
+     */
+    @Async
+    @Transactional
+    fun updateLastUsedAsync(tokenId: UUID) {
+        try {
+            apiTokenRepository.updateLastUsed(tokenId)
+        } catch (e: Exception) {
+            logger.warn { "Failed to update last used timestamp for token $tokenId: ${e.message}" }
+        }
+    }
+
+    private fun ApiToken.toAdminApiTokenDto(): AdminApiTokenDto =
+        AdminApiTokenDto(
+            id = this.id.value,
+            userId = this.user.id.value,
+            userLogin = this.user.login,
+            name = this.name,
+            scopes = this.scopes.split(",").filter { it.isNotBlank() },
+            createdAt = this.createdAt,
+            lastUsedAt = this.lastUsedAt,
+            usageCount = this.usageCount,
+            expiresAt = this.expiresAt,
+            isActive = this.isActive,
+        )
+}

--- a/src/main/resources/liquibase.xml
+++ b/src/main/resources/liquibase.xml
@@ -669,4 +669,42 @@
             ALTER TABLE book ADD original_title varchar(1000);
         </sql>
     </changeSet>
+    <changeSet id="add_api_token" author="byng">
+        <createTable tableName="api_token">
+            <column name="id" type="binary(16)" remarks="Technical ID">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="user_id" type="binary(16)" remarks="User ID">
+                <constraints foreignKeyName="fk_api_token_user_id" references="user(id)" nullable="false" deleteCascade="true" />
+            </column>
+            <column name="token_hash" type="varchar(64)" remarks="SHA-256 hash of token">
+                <constraints nullable="false" unique="true" />
+            </column>
+            <column name="name" type="varchar(100)" remarks="User-friendly name">
+                <constraints nullable="false" />
+            </column>
+            <column name="scopes" type="varchar(500)" remarks="Comma-separated scopes">
+                <constraints nullable="false" />
+            </column>
+            <column name="created_at" type="timestamp" remarks="Date of creation">
+                <constraints nullable="false" />
+            </column>
+            <column name="last_used_at" type="timestamp" remarks="Date of last use">
+            </column>
+            <column name="usage_count" type="bigint" remarks="Number of times used" defaultValueNumeric="0">
+                <constraints nullable="false" />
+            </column>
+            <column name="expires_at" type="timestamp" remarks="Optional expiration date">
+            </column>
+            <column name="is_active" type="boolean" remarks="Token active status" defaultValueBoolean="true">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+        <createIndex tableName="api_token" indexName="idx_api_token_hash">
+            <column name="token_hash" />
+        </createIndex>
+        <createIndex tableName="api_token" indexName="idx_api_token_user_id">
+            <column name="user_id" />
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/kotlin/io/github/bayang/jelu/security/ScopePathMatcherTest.kt
+++ b/src/test/kotlin/io/github/bayang/jelu/security/ScopePathMatcherTest.kt
@@ -1,0 +1,741 @@
+package io.github.bayang.jelu.security
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ScopePathMatcherTest {
+    // Books endpoints - READ scope
+    @Test
+    fun `test books GET with books read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test books GET with path parameters and books read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books/123",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test books GET without required scope returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "GET",
+                listOf("reading:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test books GET with multiple scopes including required returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "GET",
+                listOf("reading:read", "books:read", "reviews:read"),
+            ),
+        )
+    }
+
+    // Books endpoints - WRITE scope
+    @Test
+    fun `test books POST with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "POST",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test books PUT with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "PUT",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test books DELETE with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "DELETE",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test books POST with only read scope returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "POST",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    // Authors endpoints
+    @Test
+    fun `test authors GET with books read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/authors",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test authors POST with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/authors",
+                "POST",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test authors PUT with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/authors",
+                "PUT",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test authors DELETE with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/authors",
+                "DELETE",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    // Tags endpoints
+    @Test
+    fun `test tags GET with books read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/tags",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test tags POST with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/tags",
+                "POST",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    // Series endpoints
+    @Test
+    fun `test series GET with books read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/series",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test series POST with books write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/series",
+                "POST",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    // Publishers endpoints
+    @Test
+    fun `test publishers GET with books read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/publishers",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    // Reading events - userbooks
+    @Test
+    fun `test userbooks GET with reading read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/userbooks",
+                "GET",
+                listOf("reading:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test userbooks POST with reading write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/userbooks",
+                "POST",
+                listOf("reading:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test userbooks PUT with reading write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/userbooks",
+                "PUT",
+                listOf("reading:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test userbooks DELETE with reading write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/userbooks",
+                "DELETE",
+                listOf("reading:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test userbooks POST with only read scope returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/userbooks",
+                "POST",
+                listOf("reading:read"),
+            ),
+        )
+    }
+
+    // Reading events
+    @Test
+    fun `test reading-events GET with reading read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/reading-events",
+                "GET",
+                listOf("reading:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test reading-events POST with reading write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/reading-events",
+                "POST",
+                listOf("reading:write"),
+            ),
+        )
+    }
+
+    // Reviews
+    @Test
+    fun `test reviews GET with reviews read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/reviews",
+                "GET",
+                listOf("reviews:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test reviews POST with reviews write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/reviews",
+                "POST",
+                listOf("reviews:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test reviews PUT with reviews write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/reviews",
+                "PUT",
+                listOf("reviews:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test reviews DELETE with reviews write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/reviews",
+                "DELETE",
+                listOf("reviews:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test reviews POST with only read scope returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/reviews",
+                "POST",
+                listOf("reviews:read"),
+            ),
+        )
+    }
+
+    // Lists - shelves
+    @Test
+    fun `test shelves GET with lists read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/shelves",
+                "GET",
+                listOf("lists:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test shelves POST with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/shelves",
+                "POST",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test shelves DELETE with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/shelves",
+                "DELETE",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    // Lists - quotes
+    @Test
+    fun `test quotes GET with lists read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/quotes",
+                "GET",
+                listOf("lists:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test quotes POST with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/quotes",
+                "POST",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test quotes PUT with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/quotes",
+                "PUT",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test quotes DELETE with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/quotes",
+                "DELETE",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    // Lists - custom-lists
+    @Test
+    fun `test custom-lists GET with lists read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/custom-lists",
+                "GET",
+                listOf("lists:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test custom-lists POST with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/custom-lists",
+                "POST",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test custom-lists PUT with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/custom-lists",
+                "PUT",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test custom-lists DELETE with lists write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/custom-lists",
+                "DELETE",
+                listOf("lists:write"),
+            ),
+        )
+    }
+
+    // Import/Export
+    @Test
+    fun `test imports GET with import write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/imports",
+                "GET",
+                listOf("import:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test imports POST with import write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/imports",
+                "POST",
+                listOf("import:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test files GET with import write scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/files",
+                "GET",
+                listOf("import:write"),
+            ),
+        )
+    }
+
+    // Metadata
+    @Test
+    fun `test metadata GET with metadata read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/metadata",
+                "GET",
+                listOf("metadata:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test metadata POST with metadata read scope returns true`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/metadata",
+                "POST",
+                listOf("metadata:read"),
+            ),
+        )
+    }
+
+    // Case insensitivity tests
+    @Test
+    fun `test method matching is case insensitive for GET`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "get",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test method matching is case insensitive for POST`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "post",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test method matching is case insensitive for PUT`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "Put",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test method matching is case insensitive for DELETE`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "DeLeTe",
+                listOf("books:write"),
+            ),
+        )
+    }
+
+    // Default deny tests - security critical
+    @Test
+    fun `test unmapped path returns false by default`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/unmapped-endpoint",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test unmapped path returns false even with all scopes`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/unmapped-endpoint",
+                "GET",
+                TokenScope.allScopeNames(),
+            ),
+        )
+    }
+
+    @Test
+    fun `test empty path returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test empty scopes returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "GET",
+                emptyList(),
+            ),
+        )
+    }
+
+    @Test
+    fun `test invalid scope name returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "GET",
+                listOf("invalid:scope"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test path with different method returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "POST",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test partial path match does not grant access`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/book", // Missing 's', should not match /api/v1/books
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    // Path prefix matching tests
+    @Test
+    fun `test path with trailing slash matches`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books/",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test path with query parameters matches`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books?page=1&size=10",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test path with multiple segments matches`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books/123/reviews",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    // Edge cases
+    @Test
+    fun `test root API path returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test non-API path returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/health",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test different API version returns false`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v2/books",
+                "GET",
+                listOf("books:read"),
+            ),
+        )
+    }
+
+    // Multiple scopes scenarios
+    @Test
+    fun `test user with both read and write scopes can read`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "GET",
+                listOf("books:read", "books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test user with both read and write scopes can write`() {
+        assertTrue(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "POST",
+                listOf("books:read", "books:write"),
+            ),
+        )
+    }
+
+    @Test
+    fun `test user with unrelated scopes cannot access endpoint`() {
+        assertFalse(
+            ScopePathMatcher.hasRequiredScope(
+                "/api/v1/books",
+                "GET",
+                listOf("reading:read", "reviews:read", "lists:read"),
+            ),
+        )
+    }
+}

--- a/src/test/kotlin/io/github/bayang/jelu/service/ApiTokenServiceTest.kt
+++ b/src/test/kotlin/io/github/bayang/jelu/service/ApiTokenServiceTest.kt
@@ -1,0 +1,289 @@
+package io.github.bayang.jelu.service
+
+import io.github.bayang.jelu.dto.CreateApiTokenDto
+import io.github.bayang.jelu.dto.CreateUserDto
+import io.github.bayang.jelu.dto.UpdateApiTokenDto
+import io.github.bayang.jelu.dto.UserDto
+import io.github.bayang.jelu.errors.JeluValidationException
+import io.github.bayang.jelu.security.TokenScope
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApiTokenServiceTest(
+    @Autowired private val apiTokenService: ApiTokenService,
+    @Autowired private val userService: UserService,
+) {
+    private lateinit var testUser: UserDto
+
+    @BeforeAll
+    fun setupUser() {
+        testUser = userService.save(CreateUserDto(login = "apitokenuser", password = "1234", isAdmin = true))
+    }
+
+    @AfterAll
+    fun tearDown() {
+        // Clean up tokens first (they have FK to user)
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+        // Then clean up user
+        userService.findAll(null).filter { it.login == "apitokenuser" }.forEach {
+            userService.deleteUser(it.id!!)
+        }
+    }
+
+    @Test
+    fun testTokenGeneration() {
+        val rawToken = apiTokenService.generateRawToken()
+        Assertions.assertTrue(rawToken.startsWith("jelu_"))
+        Assertions.assertEquals(37, rawToken.length) // "jelu_" (5) + 32 hex chars
+        Assertions.assertTrue(apiTokenService.isValidTokenFormat(rawToken))
+    }
+
+    @Test
+    fun testTokenHashing() {
+        val rawToken = "jelu_0123456789abcdef0123456789abcdef"
+        val hash1 = apiTokenService.hashToken(rawToken)
+        val hash2 = apiTokenService.hashToken(rawToken)
+
+        // Same input should produce same hash
+        Assertions.assertEquals(hash1, hash2)
+        // Hash should be 64 chars (SHA-256 hex)
+        Assertions.assertEquals(64, hash1.length)
+        // Hash should be different from input
+        Assertions.assertNotEquals(rawToken, hash1)
+    }
+
+    @Test
+    fun testInvalidTokenFormats() {
+        Assertions.assertFalse(apiTokenService.isValidTokenFormat("invalid"))
+        Assertions.assertFalse(apiTokenService.isValidTokenFormat("jelu_tooshort"))
+        Assertions.assertFalse(apiTokenService.isValidTokenFormat("jelu_INVALID_HEX_CHARACTERS_HERE!!"))
+        Assertions.assertFalse(apiTokenService.isValidTokenFormat("other_0123456789abcdef0123456789abcdef"))
+    }
+
+    @Test
+    fun testCreateAndFindToken() {
+        // Clean up any existing tokens
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+
+        val createDto =
+            CreateApiTokenDto(
+                name = "Test Token",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName, TokenScope.BOOKS_WRITE.scopeName),
+                expiresAt = Instant.now().plus(30, ChronoUnit.DAYS),
+            )
+
+        val createdResult = apiTokenService.createToken(createDto, testUser.id!!)
+
+        // Verify the raw token is returned
+        Assertions.assertNotNull(createdResult.rawToken)
+        Assertions.assertTrue(createdResult.rawToken.startsWith("jelu_"))
+        Assertions.assertTrue(apiTokenService.isValidTokenFormat(createdResult.rawToken))
+
+        // Verify the token DTO
+        Assertions.assertEquals("Test Token", createdResult.token.name)
+        Assertions.assertEquals(testUser.id, createdResult.token.userId)
+        Assertions.assertTrue(createdResult.token.scopes.contains(TokenScope.BOOKS_READ.scopeName))
+        Assertions.assertTrue(createdResult.token.scopes.contains(TokenScope.BOOKS_WRITE.scopeName))
+        Assertions.assertTrue(createdResult.token.isActive)
+        Assertions.assertEquals(0, createdResult.token.usageCount)
+        Assertions.assertNull(createdResult.token.lastUsedAt)
+
+        // Find by user ID
+        val tokens = apiTokenService.findByUserId(testUser.id!!)
+        Assertions.assertEquals(1, tokens.size)
+        Assertions.assertEquals("Test Token", tokens[0].name)
+
+        // Find by ID
+        val foundToken = apiTokenService.findById(createdResult.token.id)
+        Assertions.assertNotNull(foundToken)
+        Assertions.assertEquals("Test Token", foundToken!!.name)
+    }
+
+    @Test
+    fun testValidateToken() {
+        // Clean up any existing tokens
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+
+        val createDto =
+            CreateApiTokenDto(
+                name = "Validation Test Token",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName),
+            )
+
+        val createdResult = apiTokenService.createToken(createDto, testUser.id!!)
+
+        // Valid token should be validated
+        val validatedToken = apiTokenService.validateToken(createdResult.rawToken)
+        Assertions.assertNotNull(validatedToken)
+        Assertions.assertEquals("Validation Test Token", validatedToken!!.name)
+
+        // Invalid token should return null
+        val invalidToken = apiTokenService.validateToken("jelu_0000000000000000000000000000000000")
+        Assertions.assertNull(invalidToken)
+    }
+
+    @Test
+    fun testUpdateToken() {
+        // Clean up any existing tokens
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+
+        val createDto =
+            CreateApiTokenDto(
+                name = "Original Name",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName),
+            )
+
+        val createdResult = apiTokenService.createToken(createDto, testUser.id!!)
+
+        // Update the token
+        val updateDto =
+            UpdateApiTokenDto(
+                name = "Updated Name",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName, TokenScope.BOOKS_WRITE.scopeName),
+                isActive = true,
+            )
+
+        val updatedToken = apiTokenService.updateToken(createdResult.token.id, testUser.id!!, updateDto)
+        Assertions.assertNotNull(updatedToken)
+        Assertions.assertEquals("Updated Name", updatedToken!!.name)
+        Assertions.assertEquals(2, updatedToken.scopes.size)
+    }
+
+    @Test
+    fun testDeactivateToken() {
+        // Clean up any existing tokens
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+
+        val createDto =
+            CreateApiTokenDto(
+                name = "Deactivate Test Token",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName),
+            )
+
+        val createdResult = apiTokenService.createToken(createDto, testUser.id!!)
+        val rawToken = createdResult.rawToken
+
+        // Token should be valid initially
+        Assertions.assertNotNull(apiTokenService.validateToken(rawToken))
+
+        // Deactivate the token
+        val updateDto = UpdateApiTokenDto(isActive = false)
+        apiTokenService.updateToken(createdResult.token.id, testUser.id!!, updateDto)
+
+        // Token should no longer be valid
+        Assertions.assertNull(apiTokenService.validateToken(rawToken))
+    }
+
+    @Test
+    fun testRevokeToken() {
+        // Clean up any existing tokens
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+
+        val createDto =
+            CreateApiTokenDto(
+                name = "Revoke Test Token",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName),
+            )
+
+        val createdResult = apiTokenService.createToken(createDto, testUser.id!!)
+
+        // Token should exist
+        Assertions.assertNotNull(apiTokenService.findById(createdResult.token.id))
+
+        // Revoke the token
+        val revoked = apiTokenService.revokeToken(createdResult.token.id, testUser.id!!)
+        Assertions.assertTrue(revoked)
+
+        // Token should no longer exist
+        Assertions.assertNull(apiTokenService.findById(createdResult.token.id))
+
+        // Revoking again should return false
+        val revokedAgain = apiTokenService.revokeToken(createdResult.token.id, testUser.id!!)
+        Assertions.assertFalse(revokedAgain)
+    }
+
+    @Test
+    fun testInvalidScopes() {
+        val createDto =
+            CreateApiTokenDto(
+                name = "Invalid Scope Token",
+                scopes = listOf("invalid:scope"),
+            )
+
+        assertThrows<JeluValidationException> {
+            apiTokenService.createToken(createDto, testUser.id!!)
+        }
+    }
+
+    @Test
+    fun testExpiredToken() {
+        // Clean up any existing tokens
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+
+        // Create token that expires in the past (should fail)
+        val pastExpiration = Instant.now().minus(1, ChronoUnit.DAYS)
+        val createDto =
+            CreateApiTokenDto(
+                name = "Expired Token",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName),
+                expiresAt = pastExpiration,
+            )
+
+        assertThrows<JeluValidationException> {
+            apiTokenService.createToken(createDto, testUser.id!!)
+        }
+    }
+
+    @Test
+    fun testMaxTokenLimit() {
+        // Clean up any existing tokens
+        apiTokenService.findByUserId(testUser.id!!).forEach {
+            apiTokenService.revokeToken(it.id, testUser.id!!, isAdmin = true)
+        }
+
+        // Create 20 tokens (the maximum)
+        for (i in 1..20) {
+            val createDto =
+                CreateApiTokenDto(
+                    name = "Token $i",
+                    scopes = listOf(TokenScope.BOOKS_READ.scopeName),
+                )
+            apiTokenService.createToken(createDto, testUser.id!!)
+        }
+
+        // 21st token should fail
+        val createDto =
+            CreateApiTokenDto(
+                name = "Token 21",
+                scopes = listOf(TokenScope.BOOKS_READ.scopeName),
+            )
+
+        assertThrows<JeluValidationException> {
+            apiTokenService.createToken(createDto, testUser.id!!)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds API token authentication to Jelu, allowing users to create personal access tokens for API access without exposing their passwords. This is particularly useful for:

- Third-party integrations
- Automation scripts
- Mobile apps
- CI/CD pipelines

Implements #281 

## Implementation

### Backend

- **Token Management**: New `ApiTokenService` handles token lifecycle (create, validate, revoke)
- **Security**: Tokens are hashed with SHA-256 before storage (never stored in plaintext)
- **Authentication Filter**: `BearerTokenAuthenticationFilter` validates Bearer tokens before Spring Security
- **Scope-Based Authorization**: Fine-grained permissions (books:read, books:write, etc.)
- **Database**: New `api_tokens` table with Liquibase migration

### Frontend

- **Token Management UI**: New page for users to create/manage/revoke tokens
- **Admin View**: Admins can see all tokens across all users
- **Copy-to-Clipboard**: One-time token display on creation

### Security Model

- Tokens are hashed (SHA-256) before storage
- Deny-by-default authorization (unmapped paths = denied)
- Scope-based fine-grained permissions
- Token expiration support
- Per-user token limits (20 max)
- Tokens never stored in session (stateless)

## Testing

### Backend Tests (345 total)

- **ApiTokenServiceTest** (280 lines): Comprehensive service layer tests
  - Token generation, hashing, validation
  - CRUD operations
  - Edge cases (expiration, invalid tokens, etc.)
  
- **ScopePathMatcherTest** (65 tests): Complete scope authorization coverage
  - All endpoint/scope mappings
  - Case insensitivity
  - Security-critical deny-by-default tests

### Manual Testing

- Token creation via UI
- Token authentication with `Authorization: Bearer jelu_...`
- Invalid token rejection
- Scope violations blocked (403 Forbidden)
- Token revocation
- Admin token management

## Screenshots

<img width="1458" height="780" alt="image" src="https://github.com/user-attachments/assets/9222a207-389d-47f4-8f33-930f3af96417" />

<img width="733" height="780" alt="image" src="https://github.com/user-attachments/assets/9205f396-ecbd-4888-aaf1-289e3bbbcc2c" />


## Notes

- Following existing pattern: `AuthHeaderFilter` has no unit tests, so `BearerTokenAuthenticationFilter` follows the same approach. Happy to add integration tests if desired.
- I'm not sure where the documentation repository that backs https://bayang.github.io/jelu-web/ is, so I don't know how to write documentation for this feature, but if you can show me how, I would be more than happy to add some.
- English localization only (other locales via Crowdin)
- No breaking changes - purely additive feature
- Tokens are prefixed with `jelu_` for easy identification

## Testing Instructions

1. Build and run: `./gradlew bootRun`
2. Log in as a user
3. Navigate to Settings → API Tokens
4. Create a new token with desired scopes
5. Copy the token (shown only once)
6. Test with curl:
      curl -H "Authorization: Bearer jelu_..." http://localhost:8080/api/v1/books

Let me know if you'd like any changes or have questions about the implementation!