### PR TITLE
feat: add currency configuration and update related components

### DIFF
--- a/src/jelu-ui/src/components/BookDetail.vue
+++ b/src/jelu-ui/src/components/BookDetail.vue
@@ -54,7 +54,7 @@ const user: ComputedRef<User> = computed(() => {
 
 let currency = localStorage.getItem("JL_CURRENCY")
 if (currency == null) {
-  currency = "EUR"
+  currency = (store?.getters.getCurrency)?.length === 3 ? store.getters.getCurrency : "EUR"
 }
 
 const book: Ref<UserBook | null> = ref(null)

--- a/src/jelu-ui/src/components/UserSettings.vue
+++ b/src/jelu-ui/src/components/UserSettings.vue
@@ -3,9 +3,12 @@ import { useLocalStorage, useTitle } from '@vueuse/core'
 import { themeChange } from 'theme-change'
 import { computed, inject, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StyledTitle from './StyledTitle.vue'
+import { key } from '../store'
+import { useStore } from 'vuex'
 
 useTitle('Jelu | User settings')
+
+const store = useStore(key)
 
 const { t, locale, availableLocales } = useI18n({
       inheritLocale: true,
@@ -65,7 +68,10 @@ watch(() => locale.value,(newValue, oldValue) => {
   storedLanguage.value = newValue
 })
 
-const currency = ref("EUR")
+const configCurrency = (store?.getters.getCurrency)
+const defaultCurrency = (configCurrency)?.length === 3 ? configCurrency : "EUR"
+const currency = ref(defaultCurrency)
+
 const saved = localStorage.getItem("JL_CURRENCY")
 if (saved != null) {
   currency.value = saved

--- a/src/jelu-ui/src/components/UserStats.vue
+++ b/src/jelu-ui/src/components/UserStats.vue
@@ -9,6 +9,10 @@ import useTypography from '../composables/typography';
 import { MonthStats, TotalsStats } from '../model/YearStats';
 import dataService from "../services/DataService";
 import { ObjectUtils } from '../utils/ObjectUtils';
+import { key } from '../store'
+import { useStore } from 'vuex'
+
+const store = useStore(key)
 
 const { t } = useI18n({
       inheritLocale: true,
@@ -19,7 +23,7 @@ useTitle('Jelu | Stats')
 
 let currency = localStorage.getItem("JL_CURRENCY")
 if (currency == null) {
-  currency = "EUR"
+  currency = (store?.getters.getCurrency)?.length === 3 ? store.getters.getCurrency : "EUR"
 }
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, LineController, PointElement, LineElement)

--- a/src/jelu-ui/src/model/ServerSettings.ts
+++ b/src/jelu-ui/src/model/ServerSettings.ts
@@ -5,5 +5,6 @@ export interface ServerSettings {
   metadataFetchCalibreEnabled: boolean,
   appVersion: string,
   ldapEnabled: boolean,
-  metadataPlugins: Array<PluginInfo>
+  metadataPlugins: Array<PluginInfo>,
+  currency: string
 }

--- a/src/jelu-ui/src/store.ts
+++ b/src/jelu-ui/src/store.ts
@@ -30,7 +30,8 @@ const store = createStore<State>({
         metadataFetchCalibreEnabled: false,
         ldapEnabled: false,
         appVersion: "",
-        metadataPlugins: []
+        metadataPlugins: [],
+        currency: ""
       } as ServerSettings,
     }
   },
@@ -145,6 +146,9 @@ const store = createStore<State>({
     getDisplayInitialSetup(state, getters): boolean {
       return (getters.getInitialSetup && !getters.getLdapEnabled)
     },
+    getCurrency(state): string {
+      return state.serverSettings.currency
+    }
   },
   plugins : [createLogger()],
   strict: true

--- a/src/jelu-ui/src/utils/ObjectUtils.ts
+++ b/src/jelu-ui/src/utils/ObjectUtils.ts
@@ -167,7 +167,7 @@ public static amountInLocale = (amount: number, locale: string, currency: string
   let localCurrency = currency
   console.log("amount " + amount + " locale " + locale + " currency " + currency)
   if (currency.length !== 3) {
-    console.log("wrong currency " + currency + " , go set it in the settings page, it should be the currency code, ie EUR")
+    console.log("wrong currency " + currency + ", go set it in the settings page, it should be the currency code, ie EUR")
     localCurrency = "EUR"
   }
   return amount.toLocaleString(locale, {

--- a/src/main/kotlin/io/github/bayang/jelu/config/JeluProperties.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/config/JeluProperties.kt
@@ -20,6 +20,7 @@ data class JeluProperties(
         ),
     val metadataProviders: List<MetaDataProvider>?,
     val lucene: Lucene = Lucene(indexAnalyzer = IndexAnalyzer()),
+    val currency: Currency = Currency(),
 ) {
     data class MetaDataProvider(
         var name: String,
@@ -93,4 +94,9 @@ data class JeluProperties(
         var dataDirectory: String = "",
         var indexAnalyzer: IndexAnalyzer,
     )
+
+    data class Currency(
+        var code: String = "",
+    )
+
 }

--- a/src/main/kotlin/io/github/bayang/jelu/controllers/ServerSettingsController.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/controllers/ServerSettingsController.kt
@@ -26,6 +26,7 @@ class ServerSettingsController(
             buildProperties.version ?: "NA",
             ldapEnabled = properties.auth.ldap.enabled,
             metadataPlugins = plugins,
+            currency = properties.currency.code,
         )
     }
 }

--- a/src/main/kotlin/io/github/bayang/jelu/dto/ServerSettingsDto.kt
+++ b/src/main/kotlin/io/github/bayang/jelu/dto/ServerSettingsDto.kt
@@ -12,4 +12,5 @@ data class ServerSettingsDto(
     val appVersion: String,
     val ldapEnabled: Boolean,
     val metadataPlugins: List<PluginInfo> = listOf(),
+    val currency: String,
 )


### PR DESCRIPTION
EUR stays as hardcoded default, so existing instances will not experience any changes. 

Now administrator can set default instance currency using 
```
JELU_CURRENCY_CODE=USD
``` 
or 
```yml
jelu:
  currency:
    code: USD
```

